### PR TITLE
Feature - Allow Reels in DMs 

### DIFF
--- a/app/src/main/java/ps/reso/instaeclipse/mods/network/Interceptor.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/network/Interceptor.java
@@ -95,6 +95,16 @@ public class Interceptor {
                                                 || uri.getPath().contains("mixed_media")
                                                 || uri.getPath().contains("mixed_media/discover/stream/");
                                     }
+                                    if (FeatureFlags.disableReelsExceptDM) {
+                                        if (uri.getPath().startsWith("/api/v1/direct_v2/")) {
+                                            return;
+                                        }
+                                        shouldDrop |= (uri.getPath().startsWith("/api/v1/clips/") && uri.getQuery() != null
+                                                       && (uri.getQuery().contains("next_media_ids=")
+                                                        || uri.getQuery().contains("max_id=")))
+                                                   || uri.getPath().contains("/clips/discover/")
+                                                   || uri.getPath().contains("/mixed_media/discover/stream/");
+                                    }
                                     if (FeatureFlags.disableExplore) {
                                         shouldDrop |= uri.getPath().contains("/discover/topical_explore")
                                                 || uri.getPath().contains("/discover/topical_explore_stream")

--- a/app/src/main/java/ps/reso/instaeclipse/utils/core/SettingsManager.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/core/SettingsManager.java
@@ -43,6 +43,7 @@ public class SettingsManager {
         editor.putBoolean("disableStories", FeatureFlags.disableStories);
         editor.putBoolean("disableFeed", FeatureFlags.disableFeed);
         editor.putBoolean("disableReels", FeatureFlags.disableReels);
+        editor.putBoolean("disableReelsExceptDM", FeatureFlags.disableReelsExceptDM);
         editor.putBoolean("disableExplore", FeatureFlags.disableExplore);
         editor.putBoolean("disableComments", FeatureFlags.disableComments);
 
@@ -92,6 +93,7 @@ public class SettingsManager {
         FeatureFlags.disableStories = prefs.getBoolean("disableStories", false);
         FeatureFlags.disableFeed = prefs.getBoolean("disableFeed", false);
         FeatureFlags.disableReels = prefs.getBoolean("disableReels", false);
+        FeatureFlags.disableReelsExceptDM = prefs.getBoolean("disableReelsExceptDM", false);
         FeatureFlags.disableExplore = prefs.getBoolean("disableExplore", false);
         FeatureFlags.disableComments = prefs.getBoolean("disableComments", false);
 

--- a/app/src/main/java/ps/reso/instaeclipse/utils/dialog/DialogUtils.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/dialog/DialogUtils.java
@@ -505,6 +505,7 @@ public class DialogUtils {
                 createSwitch(context, "Disable Stories", FeatureFlags.disableStories),
                 createSwitch(context, "Disable Feed", FeatureFlags.disableFeed),
                 createSwitch(context, "Disable Reels", FeatureFlags.disableReels),
+                createSwitch(context, "Disable Reels Except in DMs", FeatureFlags.disableReelsExceptDM),
                 createSwitch(context, "Disable Explore", FeatureFlags.disableExplore),
                 createSwitch(context, "Disable Comments", FeatureFlags.disableComments)
         };
@@ -548,8 +549,9 @@ public class DialogUtils {
             FeatureFlags.disableStories = switches[0].isChecked();
             FeatureFlags.disableFeed = switches[1].isChecked();
             FeatureFlags.disableReels = switches[2].isChecked();
-            FeatureFlags.disableExplore = switches[3].isChecked();
-            FeatureFlags.disableComments = switches[4].isChecked();
+            FeatureFlags.disableReelsExceptDM = switches[3].isChecked();
+            FeatureFlags.disableExplore = switches[4].isChecked();
+            FeatureFlags.disableComments = switches[5].isChecked();
         });
 
         SettingsManager.saveAllFlags();

--- a/app/src/main/java/ps/reso/instaeclipse/utils/feature/FeatureFlags.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/feature/FeatureFlags.java
@@ -30,6 +30,7 @@ public class FeatureFlags {
     public static boolean disableStories = false;
     public static boolean disableFeed = false;
     public static boolean disableReels = false;
+    public static boolean disableReelsExceptDM = false;
     public static boolean disableExplore = false;
     public static boolean disableComments = false;
 


### PR DESCRIPTION
Adds a new toggle "Disable Reels Except in DMs"

Allows for viewing, sending and receiving reels from your contacts in DMs, yet still blocks the reel discover scroll feed.