### PR TITLE
Version 0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ It uses [DexKit](https://github.com/LuckyPray/DexKit) for dynamic class/method d
 | Copy Comment | Copy any comment text with one tap |
 | View Story Mentions | See all @mentions in a story at once |
 | Disable Discover People | Remove the "People you may know" section |
+| Disable Double Tap to Like | Prevent accidentally liking posts and reels by double tapping |
 
 </details>
 
@@ -176,6 +177,9 @@ Force stop Instagram, then reopen it.
 
 **4. Open InstaEclipse**
 Inside Instagram, **long-press the search icon** to open the InstaEclipse menu.
+
+ > [!CAUTION]
+> **Hide My Applist users:** Do **not** add InstaEclipse to the hidden apps list. InstaEclipse must remain visible to Instagram — hiding it will cause crashes or features to stop working entirely.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ It uses [DexKit](https://github.com/LuckyPray/DexKit) for dynamic class/method d
 </details>
 
 <details>
+<summary><b>✨ Clean Feed</b> — See only what matters</summary>
+
+<br/>
+
+| Feature | Description |
+|---|---|
+| Hide Suggestions in Feed | Remove suggested posts, reels widgets, and other non-followed content from your feed |
+
+</details>
+
+<details>
 <summary><b>🛡️ Ad & Analytics Blocking</b> — Browse without being tracked</summary>
 
 <br/>
@@ -208,6 +219,9 @@ Force stop Instagram and clear its cache after enabling.
 
 **Not working on the Google Play version?**
 Download Instagram from [APKMirror](https://www.apkmirror.com/apk/instagram/instagram-instagram/) instead.
+
+**Some features not working even after enabling them?**
+Certain Instagram internal configurations can silently break specific features. A ready-to-use config that fixes known issues is available on Telegram — [**grab it here**](https://t.me/InstaEclipse/52).
 
 **Still stuck?**
 Join the [Telegram group](https://t.me/instaEclipse_discussion) and ask — someone will help.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "ps.reso.instaeclipse"
         minSdkVersion 28
         targetSdk 36
-        versionCode 13
-        versionName '0.5.0'
+        versionCode 14
+        versionName '0.5.1'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/ps/reso/instaeclipse/Xposed/Module.java
+++ b/app/src/main/java/ps/reso/instaeclipse/Xposed/Module.java
@@ -1,7 +1,5 @@
 package ps.reso.instaeclipse.Xposed;
 
-import static de.robv.android.xposed.XposedHelpers.findAndHookMethod;
-
 import android.annotation.SuppressLint;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -20,7 +18,6 @@ import java.util.Map;
 import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.IXposedHookZygoteInit;
 import de.robv.android.xposed.XC_MethodHook;
-import de.robv.android.xposed.XC_MethodReplacement;
 import de.robv.android.xposed.XSharedPreferences;
 import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.XposedHelpers;
@@ -95,22 +92,6 @@ public class Module implements IXposedHookLoadPackage, IXposedHookZygoteInit {
         // Ensure preferences are loaded
 
 
-        // Hook into your module
-        if (lpparam.packageName.equals(CommonUtils.MY_PACKAGE_NAME)) {
-            try {
-                if (dexKitBridge == null) {
-                    System.load(moduleLibDir + "/libdexkit.so");
-                    dexKitBridge = DexKitBridge.create(moduleSourceDir);
-                }
-
-                // Hook your module
-                hookOwnModule(lpparam);
-
-            } catch (Exception e) {
-                XposedBridge.log("(InstaEclipse): Failed to initialize DexKitBridge for InstaEclipse: " + e.getMessage());
-            }
-        }
-
         // Hook into Instagram and its clones
         if (SUPPORTED_PACKAGES.contains(lpparam.packageName)) {
             try {
@@ -133,15 +114,6 @@ public class Module implements IXposedHookLoadPackage, IXposedHookZygoteInit {
             } catch (Exception e) {
                 XposedBridge.log("(InstaEclipse): Failed to initialize DexKitBridge for " + lpparam.packageName + ": " + e.getMessage());
             }
-        }
-    }
-
-    private void hookOwnModule(XC_LoadPackage.LoadPackageParam lpparam) {
-        try {
-            findAndHookMethod(CommonUtils.MY_PACKAGE_NAME + ".MainActivity", lpparam.classLoader, "isModuleActive", XC_MethodReplacement.returnConstant(true));
-            // XposedBridge.log("InstaEclipse | Successfully hooked isModuleActive().");
-        } catch (Exception e) {
-            XposedBridge.log("(InstaEclipse): Failed to hook MainActivity: " + e.getMessage());
         }
     }
 

--- a/app/src/main/java/ps/reso/instaeclipse/Xposed/Module.java
+++ b/app/src/main/java/ps/reso/instaeclipse/Xposed/Module.java
@@ -23,6 +23,8 @@ import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.XposedHelpers;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
 import ps.reso.instaeclipse.mods.ads.AdBlocker;
+import ps.reso.instaeclipse.mods.feed.HideSuggestedFeedItemsHook;
+import ps.reso.instaeclipse.mods.feed.ReelsClientHook;
 import ps.reso.instaeclipse.mods.ads.TrackingLinkDisable;
 import ps.reso.instaeclipse.mods.devops.BuildExpiredPopupHook;
 import ps.reso.instaeclipse.mods.devops.DevOptionsUnlockHook;
@@ -235,6 +237,20 @@ public class Module implements IXposedHookLoadPackage, IXposedHookZygoteInit {
                         new GhostStorySeenHook().handleStorySeenBlock(dexKitBridge); // Story Seen
                     } catch (Throwable ignored) {
                         XposedBridge.log("(InstaEclipse | GhostStorySeen): ❌ Failed to hook");
+                    }
+
+                    // Hide in-feed widget units (suggested users panels, surveys, carousels, etc.)
+                    try {
+                        new HideSuggestedFeedItemsHook().install(dexKitBridge, hostClassLoader);
+                    } catch (Throwable ignored) {
+                        XposedBridge.log("(InstaEclipse | HideSuggested): ❌ Failed to hook");
+                    }
+
+                    // Client-side reels blocker (intercepts the reels viewer)
+                    try {
+                        new ReelsClientHook().install(hostClassLoader);
+                    } catch (Throwable ignored) {
+                        XposedBridge.log("(InstaEclipse | ReelsClient): ❌ Failed to hook");
                     }
 
                     // Ads Blocker

--- a/app/src/main/java/ps/reso/instaeclipse/Xposed/Module.java
+++ b/app/src/main/java/ps/reso/instaeclipse/Xposed/Module.java
@@ -45,6 +45,7 @@ import ps.reso.instaeclipse.mods.media.ProfilePicDownloadHook;
 import ps.reso.instaeclipse.mods.media.ReelDownloadHook;
 import ps.reso.instaeclipse.mods.media.StoryDownloadHook;
 import ps.reso.instaeclipse.mods.misc.CommentCopyHook;
+import ps.reso.instaeclipse.mods.misc.DisableDoubleTapLikeHook;
 import ps.reso.instaeclipse.mods.misc.DisableStoryFlippingHook;
 import ps.reso.instaeclipse.mods.misc.DisableVideoAutoPlayHook;
 import ps.reso.instaeclipse.mods.misc.StoryMentionHook;
@@ -286,6 +287,13 @@ public class Module implements IXposedHookLoadPackage, IXposedHookZygoteInit {
                         new CommentCopyHook().install(lpparam.classLoader);
                     } catch (Throwable ignored) {
                         XposedBridge.log("(InstaEclipse | CopyComment): ❌ Failed to hook");
+                    }
+
+                    // Disable Double Tap to Like
+                    try {
+                        new DisableDoubleTapLikeHook().install(dexKitBridge, lpparam.classLoader);
+                    } catch (Throwable ignored) {
+                        XposedBridge.log("(InstaEclipse | DoubleTapLike): ❌ Failed to hook");
                     }
 
                     try {

--- a/app/src/main/java/ps/reso/instaeclipse/fragments/FeaturesFragment.java
+++ b/app/src/main/java/ps/reso/instaeclipse/fragments/FeaturesFragment.java
@@ -769,7 +769,8 @@ public class FeaturesFragment extends Fragment {
         defs.add(Arrays.asList(
                 createMasterSwitch(getString(R.string.ig_dialog_enable_disable_all), Arrays.asList(
                         "disableStoryFlipping", "disableVideoAutoPlay", "disableRepost", "showFollowerToast",
-                        "showFeatureToasts", "enableStoryMentions", "disableDiscoverPeople", "enableCopyComment"
+                        "showFeatureToasts", "enableStoryMentions", "disableDiscoverPeople", "enableCopyComment",
+                        "disableDoubleTapLike"
                 )),
                 createSwitch(getString(R.string.ig_dialog_misc_disable_story_autoswipe), "disableStoryFlipping"),
                 createSwitch(getString(R.string.ig_dialog_misc_disable_video_autoplay), "disableVideoAutoPlay"),
@@ -778,7 +779,8 @@ public class FeaturesFragment extends Fragment {
                 createSwitch(getString(R.string.ig_dialog_misc_show_feature_toasts), "showFeatureToasts"),
                 createSwitch(getString(R.string.ig_dialog_misc_view_story_mentions), "enableStoryMentions"),
                 createSwitch(getString(R.string.ig_dialog_misc_disable_discover_people), "disableDiscoverPeople"),
-                createSwitch(getString(R.string.ig_dialog_misc_copy_comment), "enableCopyComment")
+                createSwitch(getString(R.string.ig_dialog_misc_copy_comment), "enableCopyComment"),
+                createSwitch(getString(R.string.ig_dialog_misc_disable_double_tap_like), "disableDoubleTapLike")
         ));
 
         showMenu(getString(R.string.ig_dialog_section_misc), defs);

--- a/app/src/main/java/ps/reso/instaeclipse/fragments/FeaturesFragment.java
+++ b/app/src/main/java/ps/reso/instaeclipse/fragments/FeaturesFragment.java
@@ -594,6 +594,7 @@ public class FeaturesFragment extends Fragment {
                 createNav(getString(R.string.ig_dialog_menu_dev_options), this::loadDevMenu),
                 createNav(getString(R.string.ig_dialog_menu_ghost_settings), this::loadGhostMenu),
                 createNav(getString(R.string.ig_dialog_menu_ad_analytics), this::loadAdsMenu),
+                createNav(getString(R.string.ig_dialog_menu_clean_feed), this::loadCleanFeedMenu),
                 createNav(getString(R.string.ig_dialog_menu_distraction_free), this::loadDistractionMenu),
                 createNav(getString(R.string.ig_dialog_menu_misc), this::loadMiscMenu),
                 createNav(getString(R.string.ig_dialog_menu_downloader), this::loadDownloaderMenu)
@@ -699,6 +700,18 @@ public class FeaturesFragment extends Fragment {
 
         showMenu(getString(R.string.ig_dialog_section_ad_analytics), defs);
         currentMenu = "ads";
+    }
+
+    private void loadCleanFeedMenu() {
+        List<Object> defs = new ArrayList<>();
+
+        defs.add(getString(R.string.feat_features));
+        defs.add(Arrays.asList(
+                createSwitch(getString(R.string.ig_dialog_clean_feed_hide_suggested), "hideSuggestionsInFeed")
+        ));
+
+        showMenu(getString(R.string.ig_dialog_section_clean_feed), defs);
+        currentMenu = "cleanfeed";
     }
 
     private void loadDistractionMenu() {

--- a/app/src/main/java/ps/reso/instaeclipse/mods/feed/HideSuggestedFeedItemsHook.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/feed/HideSuggestedFeedItemsHook.java
@@ -1,0 +1,106 @@
+package ps.reso.instaeclipse.mods.feed;
+
+import org.luckypray.dexkit.DexKitBridge;
+import org.luckypray.dexkit.query.FindMethod;
+import org.luckypray.dexkit.query.matchers.MethodMatcher;
+import org.luckypray.dexkit.result.MethodData;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedBridge;
+import ps.reso.instaeclipse.utils.core.DexKitCache;
+import ps.reso.instaeclipse.utils.feature.FeatureFlags;
+import ps.reso.instaeclipse.utils.feature.FeatureStatusTracker;
+
+public class HideSuggestedFeedItemsHook {
+
+    private static final String CACHE_KEY_PARSER = "FeedItemParserClass";
+
+    public void install(DexKitBridge bridge, ClassLoader classLoader) {
+        XC_MethodHook filterHook = new XC_MethodHook() {
+            @Override
+            protected void afterHookedMethod(MethodHookParam param) {
+                if (!FeatureFlags.hideSuggestionsInFeed) return;
+
+                Object result = param.getResult();
+                if (result == null) return;
+
+                for (Field f : result.getClass().getDeclaredFields()) {
+                    if (f.getType().getName().equals("com.instagram.feed.media.Media")) {
+                        try {
+                            f.setAccessible(true);
+                            if (f.get(result) != null) return;
+                        } catch (Throwable ignored) {}
+                    }
+                }
+
+                param.setResult(null);
+                FeatureStatusTracker.setHooked("HideSuggestionsInFeed");
+            }
+        };
+
+        if (DexKitCache.isCacheValid()) {
+            String cached = DexKitCache.loadString(CACHE_KEY_PARSER);
+            if (cached != null) {
+                try {
+                    hookBridgeMethod(cached, classLoader, filterHook);
+                    return;
+                } catch (Throwable t) {
+                    XposedBridge.log("(InstaEclipse | HideSuggested): ⚠️ Cache hook failed: " + t.getMessage());
+                }
+            }
+        }
+
+        try {
+            List<MethodData> methods = bridge.findMethod(
+                    FindMethod.create().matcher(
+                            MethodMatcher.create().usingStrings(
+                                    "clips_netego", "suggested_users", "Unknown FeedItem Type"
+                            )
+                    )
+            );
+
+            if (methods.isEmpty()) {
+                methods = bridge.findMethod(
+                        FindMethod.create().matcher(
+                                MethodMatcher.create().usingStrings("clips_netego", "media_or_ad")
+                        )
+                );
+            }
+
+            if (methods.isEmpty()) {
+                methods = bridge.findMethod(
+                        FindMethod.create().matcher(
+                                MethodMatcher.create().usingStrings("clips_netego", "stories_netego", "bloks_netego")
+                        )
+                );
+            }
+
+            if (methods.isEmpty()) {
+                XposedBridge.log("(InstaEclipse | HideSuggested): ❌ FeedItem parser not found.");
+                return;
+            }
+
+            String targetClass = methods.get(0).getClassName();
+            DexKitCache.saveString(CACHE_KEY_PARSER, targetClass);
+            hookBridgeMethod(targetClass, classLoader, filterHook);
+            XposedBridge.log("(InstaEclipse | HideSuggested): ✅ Hooked: " + targetClass);
+
+        } catch (Throwable t) {
+            XposedBridge.log("(InstaEclipse | HideSuggested): ❌ Exception: " + t.getMessage());
+        }
+    }
+
+    private void hookBridgeMethod(String className, ClassLoader classLoader, XC_MethodHook hook)
+            throws ClassNotFoundException {
+        Class<?> clazz = Class.forName(className, false, classLoader);
+        for (Method m : clazz.getDeclaredMethods()) {
+            if (m.isBridge()) {
+                XposedBridge.hookMethod(m, hook);
+            }
+        }
+    }
+}

--- a/app/src/main/java/ps/reso/instaeclipse/mods/feed/ReelsClientHook.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/feed/ReelsClientHook.java
@@ -1,0 +1,32 @@
+package ps.reso.instaeclipse.mods.feed;
+
+import android.view.MotionEvent;
+
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedBridge;
+import de.robv.android.xposed.XposedHelpers;
+import ps.reso.instaeclipse.utils.feature.FeatureFlags;
+import ps.reso.instaeclipse.utils.feature.FeatureStatusTracker;
+
+public class ReelsClientHook {
+
+    private static final String TARGET_CLASS = "instagram.features.clips.viewer.ui.ClipsSwipeRefreshLayout";
+
+    public void install(ClassLoader classLoader) {
+        try {
+            XposedHelpers.findAndHookMethod(TARGET_CLASS, classLoader,
+                    "onInterceptTouchEvent", MotionEvent.class,
+                    new XC_MethodHook() {
+                        @Override
+                        protected void beforeHookedMethod(MethodHookParam param) {
+                            if (!FeatureFlags.disableReels && !FeatureFlags.disableReelsExceptDM) return;
+                            param.setResult(true);
+                            FeatureStatusTracker.setHooked("DisableReels");
+                        }
+                    });
+            XposedBridge.log("(InstaEclipse | ReelsClient): ✅ Hooked reels swipe layout");
+        } catch (Throwable t) {
+            XposedBridge.log("(InstaEclipse | ReelsClient): ❌ " + t.getMessage());
+        }
+    }
+}

--- a/app/src/main/java/ps/reso/instaeclipse/mods/ghost/GhostChannelMarkAsReadHook.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/ghost/GhostChannelMarkAsReadHook.java
@@ -19,51 +19,56 @@ public class GhostChannelMarkAsReadHook {
 
     private static final String CHANNEL_TAG = "ie_channel_seen";
 
+    // Cached once on first use — resource IDs are constant for a given app install.
+    private static volatile int sCachedSeenStateId = 0;
+    private static volatile int sCachedHeaderButtonsId = 0;
+
     public void install(ClassLoader classLoader) {
         try {
             XposedHelpers.findAndHookMethod(View.class, "onAttachedToWindow", new XC_MethodHook() {
                 @Override
                 protected void afterHookedMethod(MethodHookParam param) {
+                    // Bail immediately if the feature is off — this hook fires for every
+                    // view attachment in the entire app, so the fast path must be trivial.
+                    if (!FeatureFlags.isGhostSeen) return;
+
                     View view = (View) param.thisObject;
                     Context context = view.getContext();
 
-                    if (!FeatureFlags.isGhostSeen) return;
-
-                    // Target the specific seen state text ID used in communities/channels
-                    @SuppressLint("DiscouragedApi")
-                    int seenStateId = context.getResources().getIdentifier(
-                            "seen_state_text", "id", context.getPackageName());
-
-                    if (view.getId() == seenStateId && view instanceof TextView seenTextView) {
-
-                        // Get the ID for the buttons container
+                    if (sCachedSeenStateId == 0) {
                         @SuppressLint("DiscouragedApi")
-                        int composerContainerId = context.getResources().getIdentifier(
+                        int id = context.getResources().getIdentifier(
+                                "seen_state_text", "id", context.getPackageName());
+                        sCachedSeenStateId = id;
+                    }
+
+                    if (sCachedSeenStateId == 0 || view.getId() != sCachedSeenStateId) return;
+                    if (!(view instanceof TextView seenTextView)) return;
+
+                    if (sCachedHeaderButtonsId == 0) {
+                        @SuppressLint("DiscouragedApi")
+                        int id = context.getResources().getIdentifier(
                                 "header_right_buttons", "id", context.getPackageName());
+                        sCachedHeaderButtonsId = id;
+                    }
 
-                        if (composerContainerId != 0) {
-                            View container = view.getRootView().findViewById(composerContainerId);
-
-                            if (container instanceof ViewGroup viewGroup) {
-                                for (int i = 0; i < viewGroup.getChildCount(); i++) {
-                                    View child = viewGroup.getChildAt(i);
-                                    CharSequence description = child.getContentDescription();
-
-                                    if (description != null) {
-                                        String descStr = description.toString().toLowerCase();
-
-                                        // If it's a DM-specific button (Call or Blend), exit the hook
-                                        if (descStr.contains("audio call") ||
-                                                descStr.contains("video call") ||
-                                                descStr.contains("blend")) {
-                                            return;
-                                        }
+                    if (sCachedHeaderButtonsId != 0) {
+                        View container = view.getRootView().findViewById(sCachedHeaderButtonsId);
+                        if (container instanceof ViewGroup viewGroup) {
+                            for (int i = 0; i < viewGroup.getChildCount(); i++) {
+                                CharSequence description = viewGroup.getChildAt(i).getContentDescription();
+                                if (description != null) {
+                                    String descStr = description.toString().toLowerCase();
+                                    if (descStr.contains("audio call") ||
+                                            descStr.contains("video call") ||
+                                            descStr.contains("blend")) {
+                                        return;
                                     }
                                 }
                             }
                         }
-                        updateChannelSeen(seenTextView);
                     }
+                    updateChannelSeen(seenTextView);
                 }
             });
         } catch (Throwable t) {

--- a/app/src/main/java/ps/reso/instaeclipse/mods/ghost/GhostDMMarkAsReadHook.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/ghost/GhostDMMarkAsReadHook.java
@@ -28,23 +28,31 @@ public class GhostDMMarkAsReadHook {
         this.moduleSourceDir = moduleSourceDir;
     }
 
+    // Cached once on first use — resource IDs are constant for a given app install.
+    private static volatile int sCachedContainerId = 0;
+
     public void install(ClassLoader classLoader) {
         try {
             XposedHelpers.findAndHookMethod(View.class, "onAttachedToWindow", new XC_MethodHook() {
                 @Override
                 protected void afterHookedMethod(MethodHookParam param) {
+                    // Bail immediately if the feature is off — this hook fires for every
+                    // view attachment in the entire app, so the fast path must be trivial.
+                    if (!FeatureFlags.isGhostSeen) return;
+
                     View view = (View) param.thisObject;
-                    Context context = view.getContext();
 
-                    @SuppressLint("DiscouragedApi")
-                    int containerId = context.getResources().getIdentifier(
-                            "row_thread_composer_buttons_container", "id", context.getPackageName());
-
-                    // When we find the button container, we target its PARENT
-                    if (view.getId() == containerId && view.getParent() instanceof ViewGroup parent) {
-                        if (!FeatureFlags.isGhostSeen) return;
-                        injectIndependentButton(parent, view);
+                    if (sCachedContainerId == 0) {
+                        @SuppressLint("DiscouragedApi")
+                        int id = view.getContext().getResources().getIdentifier(
+                                "row_thread_composer_buttons_container", "id",
+                                view.getContext().getPackageName());
+                        sCachedContainerId = id;
                     }
+
+                    if (sCachedContainerId == 0 || view.getId() != sCachedContainerId) return;
+                    if (!(view.getParent() instanceof ViewGroup parent)) return;
+                    injectIndependentButton(parent, view);
                 }
             });
         } catch (Throwable t) {

--- a/app/src/main/java/ps/reso/instaeclipse/mods/ghost/ui/GhostEmojiManager.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/ghost/ui/GhostEmojiManager.java
@@ -2,53 +2,50 @@ package ps.reso.instaeclipse.mods.ghost.ui;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.graphics.Color;
+import android.graphics.PorterDuff;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
+import android.widget.ImageView;
 
 public class GhostEmojiManager {
 
     @SuppressLint("StaticFieldLeak")
-    private static TextView ghostEmojiView;
+    private static ImageView sTintedView;
 
     @SuppressLint("DiscouragedApi")
     public static void addGhostEmojiNextToInbox(Activity activity, boolean showGhost) {
         try {
-            int inboxButtonId1 = activity.getResources().getIdentifier("action_bar_inbox_button", "id", activity.getPackageName());
-            int inboxButtonId2 = activity.getResources().getIdentifier("direct_tab", "id", activity.getPackageName());
+            int id1 = activity.getResources().getIdentifier("action_bar_inbox_button", "id", activity.getPackageName());
+            int id2 = activity.getResources().getIdentifier("direct_tab", "id", activity.getPackageName());
 
-            View inboxButton1 = activity.findViewById(inboxButtonId1);
-            View inboxButton2 = activity.findViewById(inboxButtonId2);
+            View v = activity.findViewById(id1);
+            if (v == null) v = activity.findViewById(id2);
+            if (v == null) return;
 
-            View inboxButton = inboxButton1 != null ? inboxButton1 : inboxButton2;
+            ImageView iv = findImageView(v);
+            if (iv == null) return;
 
-            if (inboxButton != null) {
-                ViewGroup parent = (ViewGroup) inboxButton.getParent();
+            sTintedView = iv;
 
-                if (showGhost) {
-                    if (ghostEmojiView != null && ghostEmojiView.getParent() != null) {
-                        ((ViewGroup) ghostEmojiView.getParent()).removeView(ghostEmojiView);
-                    }
-                    if (ghostEmojiView == null || ghostEmojiView.getParent() == null) {
-                        ghostEmojiView = new TextView(activity);
-                        ghostEmojiView.setText("👻");
-                        ghostEmojiView.setTextSize(18);
-                        ghostEmojiView.setTextColor(android.graphics.Color.WHITE);
-                        ghostEmojiView.setPadding(0, inboxButton.getPaddingTop(), 0, inboxButton.getPaddingBottom());
-                        ghostEmojiView.setTranslationY(inboxButton.getTranslationY());
-
-                        int index = parent.indexOfChild(inboxButton);
-                        parent.addView(ghostEmojiView, index + 1);
-                    }
-                    ghostEmojiView.setVisibility(View.VISIBLE);
-                } else {
-                    if (ghostEmojiView != null) {
-                        ghostEmojiView.setVisibility(View.GONE);
-                    }
-                }
+            if (showGhost) {
+                iv.setColorFilter(Color.parseColor("#FFD700"), PorterDuff.Mode.SRC_ATOP);
+            } else {
+                iv.clearColorFilter();
             }
         } catch (Exception ignored) {
         }
     }
 
+    /** Recursively finds the first ImageView in the view tree. */
+    private static ImageView findImageView(View view) {
+        if (view instanceof ImageView iv) return iv;
+        if (view instanceof ViewGroup vg) {
+            for (int i = 0; i < vg.getChildCount(); i++) {
+                ImageView found = findImageView(vg.getChildAt(i));
+                if (found != null) return found;
+            }
+        }
+        return null;
+    }
 }

--- a/app/src/main/java/ps/reso/instaeclipse/mods/media/DownloadSaveService.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/media/DownloadSaveService.java
@@ -21,6 +21,8 @@ import android.widget.Toast;
 
 import androidx.documentfile.provider.DocumentFile;
 
+import ps.reso.instaeclipse.R;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -85,7 +87,7 @@ public class DownloadSaveService extends Service {
         boolean usernameFolder  = cache.getBoolean("downloaderUsernameFolder", false);
 
         if (saveUri.isEmpty()) {
-            showToast("InstaEclipse: no download folder set");
+            showToast(getString(R.string.ig_toast_no_download_folder));
             stopSelf(startId);
             return START_NOT_STICKY;
         }
@@ -101,10 +103,10 @@ public class DownloadSaveService extends Service {
                         ? downloadMergeAndSave(fUrl, fAudio, fFile, fMime, fSave, fUser, fUF)
                         : downloadAndSave(fUrl, fFile, fMime, fSave, fUser, fUF);
                 postDoneNotification(sid, "Saved: " + fFile, fMime, savedUri);
-                showToast("Saved: " + fFile);
+                showToast(getString(R.string.ig_toast_file_saved, fFile));
             } catch (Throwable e) {
                 postDoneNotification(sid, "Download failed: " + e.getMessage(), null, null);
-                showToast("Save failed: " + e.getMessage());
+                showToast(getString(R.string.ig_toast_download_failed, e.getMessage()));
             } finally {
                 stopSelf(sid);
             }

--- a/app/src/main/java/ps/reso/instaeclipse/mods/media/PostDownloadContextMenuHook.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/media/PostDownloadContextMenuHook.java
@@ -461,18 +461,38 @@ public class PostDownloadContextMenuHook {
     }
 
     private static Object findMedia(Object obj) {
-        if (obj == null) return null;
+        return findMediaDepth(obj, 0);
+    }
+
+    private static Object findMediaDepth(Object obj, int depth) {
+        if (obj == null || depth > 2) return null;
         Class<?> cls = obj.getClass();
+        if (cls.isPrimitive() || cls.getName().startsWith("java.") || cls.getName().startsWith("android."))
+            return null;
+
+        List<Object> nextLevel = depth < 2 ? new ArrayList<>() : null;
+
         while (cls != null && cls != Object.class) {
             for (Field f : cls.getDeclaredFields()) {
+                if (f.getType().isPrimitive()) continue;
                 f.setAccessible(true);
                 try {
                     Object v = f.get(obj);
-                    if (v != null && v.getClass().getName().equals("com.instagram.feed.media.Media"))
-                        return v;
+                    if (v == null) continue;
+                    String name = v.getClass().getName();
+                    if (name.equals("com.instagram.feed.media.Media")) return v;
+                    if (nextLevel != null && !name.startsWith("java.") && !name.startsWith("android."))
+                        nextLevel.add(v);
                 } catch (Throwable ignored) {}
             }
             cls = cls.getSuperclass();
+        }
+
+        if (nextLevel != null) {
+            for (Object child : nextLevel) {
+                Object found = findMediaDepth(child, depth + 1);
+                if (found != null) return found;
+            }
         }
         return null;
     }

--- a/app/src/main/java/ps/reso/instaeclipse/mods/media/ProfilePicDownloadHook.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/media/ProfilePicDownloadHook.java
@@ -47,7 +47,7 @@ public class ProfilePicDownloadHook {
     public static void install() {
         // Mark status before hook setup so the toast shows correctly
         if (FeatureFlags.enableProfileDownload) {
-            FeatureStatusTracker.setEnabled("ProfileDownload");
+            FeatureStatusTracker.setEnabled("ProfileDownload", R.string.ig_dialog_downloader_profiles);
             FeatureStatusTracker.setHooked("ProfileDownload");
         }
 

--- a/app/src/main/java/ps/reso/instaeclipse/mods/misc/DisableDoubleTapLikeHook.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/misc/DisableDoubleTapLikeHook.java
@@ -1,0 +1,108 @@
+package ps.reso.instaeclipse.mods.misc;
+
+import org.luckypray.dexkit.DexKitBridge;
+import org.luckypray.dexkit.query.FindClass;
+import org.luckypray.dexkit.query.FindMethod;
+import org.luckypray.dexkit.query.matchers.ClassMatcher;
+import org.luckypray.dexkit.query.matchers.MethodMatcher;
+import org.luckypray.dexkit.result.ClassData;
+import org.luckypray.dexkit.result.MethodData;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedBridge;
+import ps.reso.instaeclipse.utils.core.DexKitCache;
+import ps.reso.instaeclipse.utils.feature.FeatureFlags;
+
+public class DisableDoubleTapLikeHook {
+
+    private static final XC_MethodHook HOOK = new XC_MethodHook() {
+        @Override
+        protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+            if (!FeatureFlags.disableDoubleTapLike) return;
+            StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+            for (StackTraceElement frame : stack) {
+                String m = frame.getMethodName();
+                if ("onDoubleTap".equals(m) || "onDoubleTapEvent".equals(m)) {
+                    param.setResult(null);
+                    return;
+                }
+            }
+        }
+    };
+
+    public void install(DexKitBridge bridge, ClassLoader classLoader) {
+        if (DexKitCache.isCacheValid()) {
+            Method feedCached = DexKitCache.loadMethod("DoubleTapLike", classLoader);
+            Method reelsCached = DexKitCache.loadMethod("DoubleTapLikeReels", classLoader);
+            if (feedCached != null && reelsCached != null) {
+                XposedBridge.hookMethod(feedCached, HOOK);
+                XposedBridge.hookMethod(reelsCached, HOOK);
+                XposedBridge.log("(InstaEclipse | DoubleTapLike): ✅ Hooked (cached)");
+                return;
+            }
+        }
+        try {
+            findAndHook(bridge, classLoader);
+        } catch (Exception e) {
+            XposedBridge.log("(InstaEclipse | DoubleTapLike): ❌ " + e.getMessage());
+        }
+    }
+
+    private void findAndHook(DexKitBridge bridge, ClassLoader classLoader) {
+        // Feed like dispatcher
+        List<MethodData> feedMethods = bridge.findMethod(FindMethod.create()
+                .matcher(MethodMatcher.create()
+                        .usingStrings("double_tap_on_liked", "used_double_tap")
+                )
+        );
+        for (MethodData md : feedMethods) {
+            try {
+                Method m = md.getMethodInstance(classLoader);
+                DexKitCache.saveMethod("DoubleTapLike", m);
+                XposedBridge.hookMethod(m, HOOK);
+                XposedBridge.log("(InstaEclipse | DoubleTapLike): ✅ Feed hooked on " + md.getClassName() + "." + md.getMethodName());
+                break;
+            } catch (Exception e) {
+                XposedBridge.log("(InstaEclipse | DoubleTapLike): ❌ Feed: " + e.getMessage());
+            }
+        }
+        if (feedMethods.isEmpty()) {
+            XposedBridge.log("(InstaEclipse | DoubleTapLike): ❌ Feed method not found");
+        }
+
+        // Reels double-tap entry point
+        List<ClassData> reelsClasses = bridge.findClass(FindClass.create()
+                .matcher(ClassMatcher.create()
+                        .usingStrings("clips_doubletap", "LIKE_FIRED")
+                )
+        );
+        boolean reelsHooked = false;
+        for (ClassData cd : reelsClasses) {
+            List<MethodData> ecgMethods = bridge.findMethod(FindMethod.create()
+                    .matcher(MethodMatcher.create()
+                            .declaredClass(cd.getName())
+                            .usingStrings("clips_doubletap")
+                    )
+            );
+            for (MethodData md : ecgMethods) {
+                try {
+                    Method m = md.getMethodInstance(classLoader);
+                    XposedBridge.hookMethod(m, HOOK);
+                    if (!reelsHooked) {
+                        DexKitCache.saveMethod("DoubleTapLikeReels", m);
+                        reelsHooked = true;
+                    }
+                    XposedBridge.log("(InstaEclipse | DoubleTapLike): ✅ Reels hooked on " + cd.getName() + "." + md.getMethodName());
+                } catch (Exception e) {
+                    XposedBridge.log("(InstaEclipse | DoubleTapLike): ❌ Reels: " + e.getMessage());
+                }
+            }
+        }
+        if (!reelsHooked) {
+            XposedBridge.log("(InstaEclipse | DoubleTapLike): ❌ Reels entry not found");
+        }
+    }
+}

--- a/app/src/main/java/ps/reso/instaeclipse/mods/misc/DisableDoubleTapLikeHook.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/misc/DisableDoubleTapLikeHook.java
@@ -15,6 +15,7 @@ import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XposedBridge;
 import ps.reso.instaeclipse.utils.core.DexKitCache;
 import ps.reso.instaeclipse.utils.feature.FeatureFlags;
+import ps.reso.instaeclipse.utils.feature.FeatureStatusTracker;
 
 public class DisableDoubleTapLikeHook {
 
@@ -41,6 +42,7 @@ public class DisableDoubleTapLikeHook {
                 XposedBridge.hookMethod(feedCached, HOOK);
                 XposedBridge.hookMethod(reelsCached, HOOK);
                 XposedBridge.log("(InstaEclipse | DoubleTapLike): ✅ Hooked (cached)");
+                FeatureStatusTracker.setHooked("DisableDoubleTapLike");
                 return;
             }
         }
@@ -64,6 +66,7 @@ public class DisableDoubleTapLikeHook {
                 DexKitCache.saveMethod("DoubleTapLike", m);
                 XposedBridge.hookMethod(m, HOOK);
                 XposedBridge.log("(InstaEclipse | DoubleTapLike): ✅ Feed hooked on " + md.getClassName() + "." + md.getMethodName());
+                FeatureStatusTracker.setHooked("DisableDoubleTapLike");
                 break;
             } catch (Exception e) {
                 XposedBridge.log("(InstaEclipse | DoubleTapLike): ❌ Feed: " + e.getMessage());

--- a/app/src/main/java/ps/reso/instaeclipse/mods/ui/UIHookManager.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/ui/UIHookManager.java
@@ -8,6 +8,7 @@ import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.View;
@@ -36,6 +37,8 @@ import ps.reso.instaeclipse.utils.i18n.I18n;
 import ps.reso.instaeclipse.utils.toast.CustomToast;
 
 public class UIHookManager {
+
+    private static final String INSTAGRAM_MAIN_ACTIVITY = "com.instagram.mainactivity.InstagramMainActivity";
 
     @SuppressLint("StaticFieldLeak")
     private static Activity currentActivity;
@@ -136,7 +139,7 @@ public class UIHookManager {
             // Precise search for the standard onCreate(Bundle) signature
             var methods = Module.dexKitBridge.findMethod(create()
                     .matcher(org.luckypray.dexkit.query.matchers.MethodMatcher.create()
-                            .declaredClass("com.instagram.mainactivity.InstagramMainActivity")
+                            .declaredClass(INSTAGRAM_MAIN_ACTIVITY)
                             .name("onCreate")
                             .paramTypes("android.os.Bundle")
                             .returnType("void")
@@ -148,7 +151,7 @@ public class UIHookManager {
                 XposedBridge.log("(InstaEclipse): ⚠️ Specific onCreate not found, searching by signature...");
                 methods = Module.dexKitBridge.findMethod(create()
                         .matcher(org.luckypray.dexkit.query.matchers.MethodMatcher.create()
-                                .declaredClass("com.instagram.mainactivity.InstagramMainActivity")
+                                .declaredClass(INSTAGRAM_MAIN_ACTIVITY)
                                 .paramTypes("android.os.Bundle")
                                 .returnType("void")
                         )
@@ -156,11 +159,11 @@ public class UIHookManager {
             }
 
             if (!methods.isEmpty()) {
-                // Get the first match
-                var methodData = methods.get(0);
-                java.lang.reflect.Method targetMethod = methodData.getMethodInstance(classLoader);
-
-                XposedBridge.hookMethod(targetMethod, new XC_MethodHook() {
+                String methodName = methods.get(0).getName();
+                if (methodName == null || methodName.isEmpty()) {
+                    XposedBridge.log("(InstaEclipse): ❌ Invalid onCreate method name discovered");
+                } else {
+                    XposedHelpers.findAndHookMethod(INSTAGRAM_MAIN_ACTIVITY, classLoader, methodName, Bundle.class, new XC_MethodHook() {
                     @Override
                     protected void afterHookedMethod(MethodHookParam param) throws Throwable {
                         final Activity activity = (Activity) param.thisObject;
@@ -199,7 +202,8 @@ public class UIHookManager {
                             }
                         });
                     }
-                });
+                    });
+                } // end else (valid methodName)
             } else {
                 XposedBridge.log("(InstaEclipse): ❌ Failed to find any onCreate candidate in InstagramMainActivity");
             }
@@ -211,7 +215,7 @@ public class UIHookManager {
         try {
             List<MethodData> candidates = Module.dexKitBridge.findMethod(org.luckypray.dexkit.query.FindMethod.create()
                     .matcher(org.luckypray.dexkit.query.matchers.MethodMatcher.create()
-                            .declaredClass("com.instagram.mainactivity.InstagramMainActivity")
+                            .declaredClass(INSTAGRAM_MAIN_ACTIVITY)
                             .modifiers(java.lang.reflect.Modifier.PUBLIC)
                             .paramCount(0)
                             .returnType("void")
@@ -220,6 +224,8 @@ public class UIHookManager {
 
             for (MethodData methodData : candidates) {
                 String methodName = methodData.getName();
+
+                if (methodName == null || methodName.isEmpty()) continue;
 
                 // Skip constructors and static initializers
                 if (methodName.contains("<init>") || methodName.contains("<clinit>")) {
@@ -231,8 +237,7 @@ public class UIHookManager {
                     continue;
                 }
 
-                java.lang.reflect.Method targetMethod = methodData.getMethodInstance(classLoader);
-                XposedBridge.hookMethod(targetMethod, new XC_MethodHook() {
+                XposedHelpers.findAndHookMethod(INSTAGRAM_MAIN_ACTIVITY, classLoader, methodName, new XC_MethodHook() {
                     @Override
                     protected void afterHookedMethod(MethodHookParam param) {
                         final Activity activity = (Activity) param.thisObject;

--- a/app/src/main/java/ps/reso/instaeclipse/mods/ui/UIHookManager.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/ui/UIHookManager.java
@@ -186,9 +186,9 @@ public class UIHookManager {
                                         if (FeatureFlags.showFeatureToasts && !CustomToast.toastShown) {
                                             CustomToast.toastShown = true;
 
-                                            StringBuilder sb = new StringBuilder("InstaEclipse Loaded 🎯\n");
+                                            StringBuilder sb = new StringBuilder(I18n.t(activity, R.string.ig_toast_features_loaded)).append("\n");
                                             for (Map.Entry<String, Boolean> entry : FeatureStatusTracker.getStatus().entrySet()) {
-                                                sb.append(entry.getValue() ? "✅ " : "❌ ").append(entry.getKey()).append("\n");
+                                                sb.append(entry.getValue() ? "✅ " : "❌ ").append(FeatureStatusTracker.getLabel(activity, entry.getKey())).append("\n");
                                             }
                                             CustomToast.showCustomToast(activity.getApplicationContext(), sb.toString().trim());
                                         }

--- a/app/src/main/java/ps/reso/instaeclipse/mods/ui/UIHookManager.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/ui/UIHookManager.java
@@ -43,69 +43,91 @@ public class UIHookManager {
         return currentActivity;
     }
 
-    private static boolean isAnyGhostOptionEnabled() {
-        return GhostModeUtils.isGhostModeActive();
+    /**
+     * Activities that already have a pending OnGlobalLayoutListener registered.
+     * Used only to prevent duplicate listener registrations when the search view
+     * is not yet visible at setup time.
+     */
+    private static final java.util.WeakHashMap<Activity, Boolean> sGlobalListenerPending =
+            new java.util.WeakHashMap<>();
+    /**
+     * Tracks whether the GlobalLayoutListener path has completed for an activity,
+     * so we don't keep registering new listeners on every resume after search is found.
+     */
+    private static final java.util.WeakHashMap<Activity, Boolean> sSearchWiringDone =
+            new java.util.WeakHashMap<>();
+
+    // Resource IDs are constant for a given IG install — cache them statically.
+    private static volatile int sSearchTabId = 0;
+    private static volatile int sActionBarEndId = 0;
+    private static volatile int sInboxButtonId = 0;
+    private static volatile int sDirectTabId = 0;
+
+    @SuppressLint("DiscouragedApi")
+    private static void ensureIdsCached(Activity activity) {
+        if (sSearchTabId != 0 && sActionBarEndId != 0
+                && sInboxButtonId != 0 && sDirectTabId != 0) return;
+        String pkg = activity.getPackageName();
+        android.content.res.Resources res = activity.getResources();
+        if (sSearchTabId == 0)
+            sSearchTabId = res.getIdentifier("search_tab", "id", pkg);
+        if (sActionBarEndId == 0)
+            sActionBarEndId = res.getIdentifier("action_bar_end_action_buttons", "id", pkg);
+        if (sInboxButtonId == 0)
+            sInboxButtonId = res.getIdentifier("action_bar_inbox_button", "id", pkg);
+        if (sDirectTabId == 0)
+            sDirectTabId = res.getIdentifier("direct_tab", "id", pkg);
     }
 
     public static void setupHooks(Activity activity) {
-        // Hook Search Tab (open InstaEclipse Settings)
-        String[] possibleSearch = {"search_tab", "action_bar_end_action_buttons"};
-
-        for (String id : possibleSearch) {
-            @SuppressLint("DiscouragedApi")
-            int viewId = activity.getResources().getIdentifier(id, "id", activity.getPackageName());
-            View view = activity.findViewById(viewId);
-
-            if (view != null) {
-                processSearchView(activity, view, id);
-            } else {
-                // VIEW NOT FOUND YET: Wait for the layout to change and try again
-                final View decorView = activity.getWindow().getDecorView();
-                decorView.getViewTreeObserver().addOnGlobalLayoutListener(new android.view.ViewTreeObserver.OnGlobalLayoutListener() {
-                    @Override
-                    public void onGlobalLayout() {
-                        View lateView = activity.findViewById(viewId);
-                        if (lateView != null) {
-                            processSearchView(activity, lateView, id);
-                            // Remove listener so we don't keep calling this unnecessarily
-                            decorView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
-                        }
-                    }
-                });
-            }
-        }
-
-        // Hook Inbox Button (toggle Ghost Quick Options)
-        String[] possibleIds = {"action_bar_inbox_button", "direct_tab"};
-
-        for (String id : possibleIds) {
-            @SuppressLint("DiscouragedApi") int viewId = activity.getResources().getIdentifier(id, "id", activity.getPackageName());
-            View view = activity.findViewById(viewId);
-            if (view != null) {
-                hookLongPress(activity, id, v -> {
-                    GhostModeUtils.toggleSelectedGhostOptions(activity);
-                    VibrationUtil.vibrate(activity);
-                    return true;
-                });
-                break;
-            }
-        }
-
+        // Ghost emoji visibility must update on every resume (reflects current ghost state).
         addGhostEmojiNextToInbox(activity, GhostModeUtils.isGhostModeActive());
 
-    }
+        // Cache resource IDs once per IG install (string table lookup is non-trivial).
+        ensureIdsCached(activity);
 
-    // Hook long press method
-    private static void hookLongPress(Activity activity, String viewName, View.OnLongClickListener listener) {
-        try {
-            @SuppressLint("DiscouragedApi") int viewId = activity.getResources().getIdentifier(viewName, "id", activity.getPackageName());
-            View view = activity.findViewById(viewId);
-
-            if (view != null) {
-                view.setOnLongClickListener(listener);
-            }
-        } catch (Exception ignored) {
+        // Always re-apply the search long-press listener. Instagram may overwrite it after
+        // a config change (e.g. when InstaEclipse settings are toggled), so we cannot skip
+        // this on resume — we just avoid the expensive getIdentifier() call via the cache.
+        boolean anySearchFound = false;
+        if (sSearchTabId != 0) {
+            View v = activity.findViewById(sSearchTabId);
+            if (v != null) { processSearchView(activity, v, "search_tab"); anySearchFound = true; }
         }
+        if (!anySearchFound && sActionBarEndId != 0) {
+            View v = activity.findViewById(sActionBarEndId);
+            if (v != null) { processSearchView(activity, v, "action_bar_end_action_buttons"); anySearchFound = true; }
+        }
+
+        // Register at most ONE GlobalLayoutListener per activity to retry search wiring
+        // when the view isn't inflated yet. Skip if we already found search, if a listener
+        // is already pending, or if the listener already completed successfully.
+        if (!anySearchFound
+                && !Boolean.TRUE.equals(sGlobalListenerPending.get(activity))
+                && !Boolean.TRUE.equals(sSearchWiringDone.get(activity))) {
+            sGlobalListenerPending.put(activity, true);
+            final View decorView = activity.getWindow().getDecorView();
+            decorView.getViewTreeObserver().addOnGlobalLayoutListener(new android.view.ViewTreeObserver.OnGlobalLayoutListener() {
+                @Override
+                public void onGlobalLayout() {
+                    boolean found = false;
+                    if (sSearchTabId != 0) {
+                        View lateView = activity.findViewById(sSearchTabId);
+                        if (lateView != null) { processSearchView(activity, lateView, "search_tab"); found = true; }
+                    }
+                    if (!found && sActionBarEndId != 0) {
+                        View lateView = activity.findViewById(sActionBarEndId);
+                        if (lateView != null) { processSearchView(activity, lateView, "action_bar_end_action_buttons"); found = true; }
+                    }
+                    if (found) {
+                        decorView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                        sGlobalListenerPending.remove(activity);
+                        sSearchWiringDone.put(activity, true);
+                    }
+                }
+            });
+        }
+
     }
 
     public void mainActivity(ClassLoader classLoader) {
@@ -155,7 +177,7 @@ public class UIHookManager {
                                 new Handler(Looper.getMainLooper()).postDelayed(() -> {
                                     try {
                                         // Add the Ghost Emoji next to Inbox
-                                        addGhostEmojiNextToInbox(activity, isAnyGhostOptionEnabled());
+                                        addGhostEmojiNextToInbox(activity, GhostModeUtils.isGhostModeActive());
 
                                         // 3. Show Success Toast
                                         if (FeatureFlags.showFeatureToasts && !CustomToast.toastShown) {
@@ -218,7 +240,6 @@ public class UIHookManager {
                         activity.runOnUiThread(() -> {
                             try {
                                 setupHooks(activity);
-                                addGhostEmojiNextToInbox(activity, isAnyGhostOptionEnabled());
                             } catch (Exception e) {
                                 XposedBridge.log("(InstaEclipse) UI Error: " + e);
                             }
@@ -233,6 +254,27 @@ public class UIHookManager {
 
         // Hook getBottomSheetNavigator - Instagram Main
         BottomSheetHookUtil.hookBottomSheetNavigator(Module.dexKitBridge);
+
+        // Hook View.performLongClick — inbox long-press override.
+        // setOnLongClickListener is unreliable when Instagram has a parent-level touch
+        // interceptor or a custom view that overrides long-press dispatch. Hooking
+        // performLongClick() fires BEFORE any listener/interceptor chain and lets us
+        // fully own the event by returning true via setResult.
+        // This only fires when the user actually long-presses something — not a hot path.
+        XposedHelpers.findAndHookMethod(View.class, "performLongClick", new XC_MethodHook() {
+            @Override
+            protected void beforeHookedMethod(MethodHookParam param) {
+                if (sInboxButtonId == 0 && sDirectTabId == 0) return;
+                View view = (View) param.thisObject;
+                int id = view.getId();
+                if (id != sInboxButtonId && id != sDirectTabId) return;
+                Activity activity = currentActivity;
+                if (activity == null) return;
+                GhostModeUtils.toggleSelectedGhostOptions(activity);
+                VibrationUtil.vibrate(activity);
+                param.setResult(true); // consume — skip Instagram's handler entirely
+            }
+        });
 
         // Hook onResume - Model
         XposedHelpers.findAndHookMethod("com.instagram.modal.ModalActivity", classLoader, "onResume", new XC_MethodHook() {

--- a/app/src/main/java/ps/reso/instaeclipse/mods/ui/utils/BottomSheetHookUtil.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/ui/utils/BottomSheetHookUtil.java
@@ -1,11 +1,5 @@
 package ps.reso.instaeclipse.mods.ui.utils;
 
-import static ps.reso.instaeclipse.mods.ghost.ui.GhostEmojiManager.addGhostEmojiNextToInbox;
-import static ps.reso.instaeclipse.mods.ui.UIHookManager.getCurrentActivity;
-import static ps.reso.instaeclipse.mods.ui.UIHookManager.setupHooks;
-
-import android.app.Activity;
-
 import org.luckypray.dexkit.DexKitBridge;
 import org.luckypray.dexkit.query.FindMethod;
 import org.luckypray.dexkit.query.matchers.MethodMatcher;
@@ -20,7 +14,6 @@ import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XposedBridge;
 import ps.reso.instaeclipse.Xposed.Module;
 import ps.reso.instaeclipse.utils.core.DexKitCache;
-import ps.reso.instaeclipse.utils.ghost.GhostModeUtils;
 
 public class BottomSheetHookUtil {
 
@@ -72,21 +65,12 @@ public class BottomSheetHookUtil {
     }
 
     private static void hookMethod(Method reflectMethod) {
-        XposedBridge.hookMethod(reflectMethod, new XC_MethodHook() {
-            @Override
-            protected void afterHookedMethod(MethodHookParam param) {
-                final Activity activity = getCurrentActivity();
-                if (activity != null) {
-                    activity.runOnUiThread(() -> {
-                        try {
-                            setupHooks(activity);
-                            addGhostEmojiNextToInbox(activity, GhostModeUtils.isGhostModeActive());
-                        } catch (Exception ignored) {
-                        }
-                    });
-                }
-            }
-        });
+        // This getter is called on every navigation action, layout pass, and scroll
+        // event — it is a hot path. We do NOT post any work to the main thread here.
+        // onCreate and onResume hooks are responsible for all UI setup and ghost emoji
+        // updates. This hook exists only to locate the method; its body is intentionally
+        // empty to avoid any per-call overhead.
+        XposedBridge.hookMethod(reflectMethod, new XC_MethodHook() { });
         XposedBridge.log("(InstaEclipse | BottomSheet): ✅ Hooked: " + reflectMethod.getDeclaringClass().getName() + "." + reflectMethod.getName());
     }
 }

--- a/app/src/main/java/ps/reso/instaeclipse/utils/backup/SettingsBackupManager.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/backup/SettingsBackupManager.java
@@ -42,6 +42,9 @@ public class SettingsBackupManager {
         s.put("quickTogglePermanentView",FeatureFlags.quickTogglePermanentView);
         s.put("quickToggleAllowScreenshots", FeatureFlags.quickToggleAllowScreenshots);
 
+        // Clean Feed
+        s.put("hideSuggestionsInFeed",      FeatureFlags.hideSuggestionsInFeed);
+
         // Ads
         s.put("isAdBlockEnabled",        FeatureFlags.isAdBlockEnabled);
         s.put("isAnalyticsBlocked",      FeatureFlags.isAnalyticsBlocked);
@@ -113,6 +116,8 @@ public class SettingsBackupManager {
         if (s.has("quickToggleReplays"))     FeatureFlags.quickToggleReplays     = s.getBoolean("quickToggleReplays");
         if (s.has("quickTogglePermanentView")) FeatureFlags.quickTogglePermanentView = s.getBoolean("quickTogglePermanentView");
         if (s.has("quickToggleAllowScreenshots")) FeatureFlags.quickToggleAllowScreenshots = s.getBoolean("quickToggleAllowScreenshots");
+
+        if (s.has("hideSuggestionsInFeed"))     FeatureFlags.hideSuggestionsInFeed     = s.getBoolean("hideSuggestionsInFeed");
 
         if (s.has("isAdBlockEnabled"))       FeatureFlags.isAdBlockEnabled       = s.getBoolean("isAdBlockEnabled");
         if (s.has("isAnalyticsBlocked"))     FeatureFlags.isAnalyticsBlocked     = s.getBoolean("isAnalyticsBlocked");

--- a/app/src/main/java/ps/reso/instaeclipse/utils/core/DexKitCache.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/core/DexKitCache.java
@@ -68,6 +68,17 @@ public class DexKitCache {
         return cacheValid;
     }
 
+    /**
+     * Wipes all cached descriptors and marks the cache invalid for this session.
+     * DexKit will re-run its full search on the next Instagram restart.
+     */
+    public static void clearCache() {
+        if (prefs == null) return;
+        prefs.edit().clear().apply();
+        cacheValid = false;
+        XposedBridge.log("(DexKitCache) Cache manually cleared — DexKit will re-run on next launch");
+    }
+
     // ── Single method ────────────────────────────────────────────────────────
 
     public static void saveMethod(String key, Method m) {

--- a/app/src/main/java/ps/reso/instaeclipse/utils/core/SettingsManager.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/core/SettingsManager.java
@@ -75,6 +75,7 @@ public class SettingsManager {
         editor.putBoolean("disableDiscoverPeople", FeatureFlags.disableDiscoverPeople);
         editor.putBoolean("removeBuildExpiredPopup", FeatureFlags.removeBuildExpiredPopup);
         editor.putBoolean("enableCopyComment", FeatureFlags.enableCopyComment);
+        editor.putBoolean("disableDoubleTapLike", FeatureFlags.disableDoubleTapLike);
         editor.putBoolean("enablePostDownload", FeatureFlags.enablePostDownload);
         editor.putBoolean("enableStoryDownload", FeatureFlags.enableStoryDownload);
         editor.putBoolean("enableReelDownload", FeatureFlags.enableReelDownload);
@@ -150,6 +151,7 @@ public class SettingsManager {
         FeatureFlags.disableDiscoverPeople = prefs.getBoolean("disableDiscoverPeople", false);
         FeatureFlags.removeBuildExpiredPopup = prefs.getBoolean("removeBuildExpiredPopup", false);
         FeatureFlags.enableCopyComment = prefs.getBoolean("enableCopyComment", false);
+        FeatureFlags.disableDoubleTapLike = prefs.getBoolean("disableDoubleTapLike", false);
         FeatureFlags.enablePostDownload = prefs.getBoolean("enablePostDownload", false);
         FeatureFlags.enableStoryDownload = prefs.getBoolean("enableStoryDownload", false);
         FeatureFlags.enableReelDownload = prefs.getBoolean("enableReelDownload", false);

--- a/app/src/main/java/ps/reso/instaeclipse/utils/core/SettingsManager.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/core/SettingsManager.java
@@ -56,6 +56,9 @@ public class SettingsManager {
         editor.putBoolean("disableExplore", FeatureFlags.disableExplore);
         editor.putBoolean("disableComments", FeatureFlags.disableComments);
 
+        // Clean Feed
+        editor.putBoolean("hideSuggestionsInFeed", FeatureFlags.hideSuggestionsInFeed);
+
         // Ads
         editor.putBoolean("isAdBlockEnabled", FeatureFlags.isAdBlockEnabled);
         editor.putBoolean("isAnalyticsBlocked", FeatureFlags.isAnalyticsBlocked);
@@ -127,6 +130,9 @@ public class SettingsManager {
         FeatureFlags.disableReelsExceptDM = prefs.getBoolean("disableReelsExceptDM", false);
         FeatureFlags.disableExplore = prefs.getBoolean("disableExplore", false);
         FeatureFlags.disableComments = prefs.getBoolean("disableComments", false);
+
+        // Clean Feed
+        FeatureFlags.hideSuggestionsInFeed = prefs.getBoolean("hideSuggestionsInFeed", false);
 
         // Ads
         FeatureFlags.isAdBlockEnabled = prefs.getBoolean("isAdBlockEnabled", false);

--- a/app/src/main/java/ps/reso/instaeclipse/utils/dialog/DialogUtils.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/dialog/DialogUtils.java
@@ -755,7 +755,8 @@ public class DialogUtils {
                 createSwitch(context, I18n.t(context, R.string.ig_dialog_misc_show_follower_toast),     FeatureFlags.showFollowerToast),
                 createSwitch(context, I18n.t(context, R.string.ig_dialog_misc_view_story_mentions),     FeatureFlags.enableStoryMentions),
                 createSwitch(context, I18n.t(context, R.string.ig_dialog_misc_disable_discover_people), FeatureFlags.disableDiscoverPeople),
-                createSwitch(context, I18n.t(context, R.string.ig_dialog_misc_copy_comment),            FeatureFlags.enableCopyComment)
+                createSwitch(context, I18n.t(context, R.string.ig_dialog_misc_copy_comment),            FeatureFlags.enableCopyComment),
+                createSwitch(context, I18n.t(context, R.string.ig_dialog_misc_disable_double_tap_like), FeatureFlags.disableDoubleTapLike)
         };
 
         // Create Enable/Disable All switch
@@ -803,6 +804,9 @@ public class DialogUtils {
                         break;
                     case 7:
                         FeatureFlags.enableCopyComment = isChecked;
+                        break;
+                    case 8:
+                        FeatureFlags.disableDoubleTapLike = isChecked;
                         break;
                 }
 

--- a/app/src/main/java/ps/reso/instaeclipse/utils/dialog/DialogUtils.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/dialog/DialogUtils.java
@@ -105,6 +105,9 @@ public class DialogUtils {
         // 3 - Distraction-Free Instagram => OPEN PAGE
         mainLayout.addView(createClickableSection(context, I18n.t(context, R.string.ig_dialog_menu_distraction_free), () -> showDistractionOptions(context)));
 
+        // 3b - Clean Feed => OPEN PAGE
+        mainLayout.addView(createClickableSection(context, I18n.t(context, R.string.ig_dialog_menu_clean_feed), () -> showCleanFeedOptions(context)));
+
         // 4 - Misc Features => OPEN PAGE
         mainLayout.addView(createClickableSection(context, I18n.t(context, R.string.ig_dialog_menu_misc), () -> showMiscOptions(context)));
 
@@ -718,6 +721,22 @@ public class DialogUtils {
             }
             onlyInDMSwitch.setEnabled(disableReelsSwitch.isChecked());
         });
+    }
+
+
+    private static void showCleanFeedOptions(Context context) {
+        LinearLayout layout = createSwitchLayout(context);
+
+        ToggleRow hideSuggestedSwitch = createSwitch(context, I18n.t(context, R.string.ig_dialog_clean_feed_hide_suggested), FeatureFlags.hideSuggestionsInFeed);
+
+        hideSuggestedSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            FeatureFlags.hideSuggestionsInFeed = isChecked;
+            SettingsManager.saveAllFlags();
+        });
+
+        layout.addView(hideSuggestedSwitch);
+
+        showSectionDialog(context, I18n.t(context, R.string.ig_dialog_section_clean_feed), layout, () -> {});
     }
 
 

--- a/app/src/main/java/ps/reso/instaeclipse/utils/dialog/DialogUtils.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/dialog/DialogUtils.java
@@ -123,6 +123,9 @@ public class DialogUtils {
         // 9 - Restart Instagram => OPEN PAGE
         mainLayout.addView(createClickableSection(context, I18n.t(context, R.string.ig_dialog_menu_restart), () -> showRestartSection(context)));
 
+        // 10 - Clear Hooks Cache => OPEN PAGE
+        mainLayout.addView(createClickableSection(context, I18n.t(context, R.string.ig_dialog_clear_cache), () -> showClearCacheSection(context)));
+
         mainLayout.addView(createDivider(context));
 
         // Footer Credit
@@ -1023,6 +1026,28 @@ public class DialogUtils {
         });
     }
 
+
+    private static void showClearCacheSection(Context context) {
+        LinearLayout layout = new LinearLayout(context);
+        layout.setOrientation(LinearLayout.VERTICAL);
+        layout.setPadding(60, 40, 60, 40);
+        layout.setGravity(Gravity.CENTER_HORIZONTAL);
+
+        TextView message = new TextView(context);
+        message.setText(I18n.t(context, R.string.ig_dialog_clear_cache_message));
+        message.setTextColor(Color.WHITE);
+        message.setTextSize(16f);
+        message.setGravity(Gravity.CENTER);
+        message.setPadding(0, 0, 0, 30);
+
+        layout.addView(message);
+        layout.addView(createActionRow(context, "🗑", I18n.t(context, R.string.ig_dialog_clear_cache_now), "#FF9F0A", v -> {
+            ps.reso.instaeclipse.utils.core.DexKitCache.clearCache();
+            restartApp(context);
+        }));
+
+        showSectionDialog(context, I18n.t(context, R.string.ig_dialog_section_clear_cache), layout, () -> {});
+    }
 
     // ==== HELPERS ====
 

--- a/app/src/main/java/ps/reso/instaeclipse/utils/feature/FeatureFlags.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/feature/FeatureFlags.java
@@ -60,6 +60,9 @@ public class FeatureFlags {
     public static boolean removeBuildExpiredPopup = false;
     public static boolean enableCopyComment = false;
 
+    // Clean Feed
+    public static boolean hideSuggestionsInFeed = false;
+
     // Downloader
     public static boolean enablePostDownload = false;
     public static boolean enableStoryDownload = false;

--- a/app/src/main/java/ps/reso/instaeclipse/utils/feature/FeatureFlags.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/feature/FeatureFlags.java
@@ -59,6 +59,7 @@ public class FeatureFlags {
     public static boolean disableDiscoverPeople = false;
     public static boolean removeBuildExpiredPopup = false;
     public static boolean enableCopyComment = false;
+    public static boolean disableDoubleTapLike = false;
 
     // Clean Feed
     public static boolean hideSuggestionsInFeed = false;

--- a/app/src/main/java/ps/reso/instaeclipse/utils/feature/FeatureManager.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/feature/FeatureManager.java
@@ -132,5 +132,11 @@ public class FeatureManager {
         } else {
             FeatureStatusTracker.setDisabled("ProfileDownload");
         }
+
+        if (FeatureFlags.disableDoubleTapLike) {
+            FeatureStatusTracker.setEnabled("DisableDoubleTapLike");
+        } else {
+            FeatureStatusTracker.setDisabled("DisableDoubleTapLike");
+        }
     }
 }

--- a/app/src/main/java/ps/reso/instaeclipse/utils/feature/FeatureManager.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/feature/FeatureManager.java
@@ -1,140 +1,142 @@
 package ps.reso.instaeclipse.utils.feature;
 
+import ps.reso.instaeclipse.R;
+
 public class FeatureManager {
 
     public static void refreshFeatureStatus() {
         // Developer Options
         if (FeatureFlags.isDevEnabled) {
-            FeatureStatusTracker.setEnabled("DevOptions");
+            FeatureStatusTracker.setEnabled("DevOptions", R.string.ig_dialog_section_dev_options);
         } else {
             FeatureStatusTracker.setDisabled("DevOptions");
         }
 
         // Ghost Mode
         if (FeatureFlags.isGhostSeen) {
-            FeatureStatusTracker.setEnabled("GhostSeen");
+            FeatureStatusTracker.setEnabled("GhostSeen", R.string.ig_dialog_ghost_hide_dm_seen);
         } else {
             FeatureStatusTracker.setDisabled("GhostSeen");
         }
 
         if (FeatureFlags.isGhostTyping) {
-            FeatureStatusTracker.setEnabled("GhostTyping");
+            FeatureStatusTracker.setEnabled("GhostTyping", R.string.ig_dialog_ghost_hide_typing);
         } else {
             FeatureStatusTracker.setDisabled("GhostTyping");
         }
 
         if (FeatureFlags.isGhostScreenshot) {
-            FeatureStatusTracker.setEnabled("GhostScreenshot");
+            FeatureStatusTracker.setEnabled("GhostScreenshot", R.string.ig_dialog_ghost_bypass_screenshot);
         } else {
             FeatureStatusTracker.setDisabled("GhostScreenshot");
         }
 
         if (FeatureFlags.isGhostViewOnce) {
-            FeatureStatusTracker.setEnabled("GhostViewOnce");
+            FeatureStatusTracker.setEnabled("GhostViewOnce", R.string.ig_dialog_ghost_hide_view_once);
         } else {
             FeatureStatusTracker.setDisabled("GhostViewOnce");
         }
 
         if (FeatureFlags.enableUnlimitedReplays) {
-            FeatureStatusTracker.setEnabled("UnlimitedReplays");
+            FeatureStatusTracker.setEnabled("UnlimitedReplays", R.string.ig_dialog_ghost_unlimited_replays);
         } else {
             FeatureStatusTracker.setDisabled("UnlimitedReplays");
         }
 
         if (FeatureFlags.isGhostStory) {
-            FeatureStatusTracker.setEnabled("GhostStories");
+            FeatureStatusTracker.setEnabled("GhostStories", R.string.ig_dialog_ghost_hide_story_views);
         } else {
             FeatureStatusTracker.setDisabled("GhostStories");
         }
 
         if (FeatureFlags.isGhostLive) {
-            FeatureStatusTracker.setEnabled("GhostLive");
+            FeatureStatusTracker.setEnabled("GhostLive", R.string.ig_dialog_ghost_hide_live_presence);
         } else {
             FeatureStatusTracker.setDisabled("GhostLive");
         }
 
         if (FeatureFlags.allowScreenshots) {
-            FeatureStatusTracker.setEnabled("AllowScreenshots");
+            FeatureStatusTracker.setEnabled("AllowScreenshots", R.string.ig_dialog_ghost_allow_screenshots_dms);
         } else {
             FeatureStatusTracker.setDisabled("AllowScreenshots");
         }
 
         if (FeatureFlags.keepEphemeralMessages) {
-            FeatureStatusTracker.setEnabled("KeepEphemeralMessages");
+            FeatureStatusTracker.setEnabled("KeepEphemeralMessages", R.string.ig_dialog_ghost_keep_disappearing);
         } else {
             FeatureStatusTracker.setDisabled("KeepEphemeralMessages");
         }
 
         if (FeatureFlags.permanentViewMode) {
-            FeatureStatusTracker.setEnabled("PermanentViewMode");
+            FeatureStatusTracker.setEnabled("PermanentViewMode", R.string.ig_dialog_ghost_permanent_view_once);
         } else {
             FeatureStatusTracker.setDisabled("PermanentViewMode");
         }
 
         // Clean Feed
         if (FeatureFlags.hideSuggestionsInFeed) {
-            FeatureStatusTracker.setEnabled("HideSuggestionsInFeed");
+            FeatureStatusTracker.setEnabled("HideSuggestionsInFeed", R.string.ig_dialog_clean_feed_hide_suggested);
         } else {
             FeatureStatusTracker.setDisabled("HideSuggestionsInFeed");
         }
 
         // Miscellaneous
         if (FeatureFlags.disableTrackingLinks) {
-            FeatureStatusTracker.setEnabled("DisableTrackingLinks");
+            FeatureStatusTracker.setEnabled("DisableTrackingLinks", R.string.ig_dialog_ad_disable_tracking);
         } else {
             FeatureStatusTracker.setDisabled("DisableTrackingLinks");
         }
 
         if (FeatureFlags.showFollowerToast) {
-            FeatureStatusTracker.setEnabled("FollowerToast");
+            FeatureStatusTracker.setEnabled("FollowerToast", R.string.ig_dialog_misc_show_follower_toast);
         } else {
             FeatureStatusTracker.setDisabled("FollowerToast");
         }
 
         if (FeatureFlags.enableStoryMentions) {
-            FeatureStatusTracker.setEnabled("StoryMentions");
+            FeatureStatusTracker.setEnabled("StoryMentions", R.string.ig_dialog_misc_view_story_mentions);
         } else {
             FeatureStatusTracker.setDisabled("StoryMentions");
         }
 
         if (FeatureFlags.disableDiscoverPeople) {
-            FeatureStatusTracker.setEnabled("DisableDiscoverPeople");
+            FeatureStatusTracker.setEnabled("DisableDiscoverPeople", R.string.ig_dialog_misc_disable_discover_people);
         } else {
             FeatureStatusTracker.setDisabled("DisableDiscoverPeople");
         }
 
         if (FeatureFlags.removeBuildExpiredPopup) {
-            FeatureStatusTracker.setEnabled("RemoveBuildExpiredPopup");
+            FeatureStatusTracker.setEnabled("RemoveBuildExpiredPopup", R.string.ig_dialog_dev_remove_build_expired);
         } else {
             FeatureStatusTracker.setDisabled("RemoveBuildExpiredPopup");
         }
 
         if (FeatureFlags.enablePostDownload) {
-            FeatureStatusTracker.setEnabled("PostDownload");
+            FeatureStatusTracker.setEnabled("PostDownload", R.string.ig_dialog_downloader_posts);
         } else {
             FeatureStatusTracker.setDisabled("PostDownload");
         }
 
         if (FeatureFlags.enableStoryDownload) {
-            FeatureStatusTracker.setEnabled("StoryDownload");
+            FeatureStatusTracker.setEnabled("StoryDownload", R.string.ig_dialog_downloader_stories);
         } else {
             FeatureStatusTracker.setDisabled("StoryDownload");
         }
 
         if (FeatureFlags.enableReelDownload) {
-            FeatureStatusTracker.setEnabled("ReelDownload");
+            FeatureStatusTracker.setEnabled("ReelDownload", R.string.ig_dialog_downloader_reels);
         } else {
             FeatureStatusTracker.setDisabled("ReelDownload");
         }
 
         if (FeatureFlags.enableProfileDownload) {
-            FeatureStatusTracker.setEnabled("ProfileDownload");
+            FeatureStatusTracker.setEnabled("ProfileDownload", R.string.ig_dialog_downloader_profiles);
         } else {
             FeatureStatusTracker.setDisabled("ProfileDownload");
         }
 
         if (FeatureFlags.disableDoubleTapLike) {
-            FeatureStatusTracker.setEnabled("DisableDoubleTapLike");
+            FeatureStatusTracker.setEnabled("DisableDoubleTapLike", R.string.ig_dialog_misc_disable_double_tap_like);
         } else {
             FeatureStatusTracker.setDisabled("DisableDoubleTapLike");
         }

--- a/app/src/main/java/ps/reso/instaeclipse/utils/feature/FeatureManager.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/feature/FeatureManager.java
@@ -71,6 +71,13 @@ public class FeatureManager {
             FeatureStatusTracker.setDisabled("PermanentViewMode");
         }
 
+        // Clean Feed
+        if (FeatureFlags.hideSuggestionsInFeed) {
+            FeatureStatusTracker.setEnabled("HideSuggestionsInFeed");
+        } else {
+            FeatureStatusTracker.setDisabled("HideSuggestionsInFeed");
+        }
+
         // Miscellaneous
         if (FeatureFlags.disableTrackingLinks) {
             FeatureStatusTracker.setEnabled("DisableTrackingLinks");

--- a/app/src/main/java/ps/reso/instaeclipse/utils/feature/FeatureStatusTracker.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/feature/FeatureStatusTracker.java
@@ -1,25 +1,36 @@
 package ps.reso.instaeclipse.utils.feature;
 
+import android.content.Context;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import ps.reso.instaeclipse.utils.i18n.I18n;
+
 public class FeatureStatusTracker {
     private static final Map<String, Boolean> features = Collections.synchronizedMap(new HashMap<>());
+    private static final Map<String, Integer> labels   = Collections.synchronizedMap(new HashMap<>());
 
-    public static void setEnabled(String name) {
-        features.put(name, false); // default: not hooked
+    public static void setEnabled(String name, int labelResId) {
+        features.put(name, false);
+        labels.put(name, labelResId);
     }
 
     public static void setDisabled(String name) {
         features.remove(name);
+        labels.remove(name);
     }
-
 
     public static void setHooked(String name) {
         if (features.containsKey(name)) {
             features.put(name, true);
         }
+    }
+
+    public static String getLabel(Context ctx, String key) {
+        Integer resId = labels.get(key);
+        return resId != null ? I18n.t(ctx, resId) : key;
     }
 
     public static Map<String, Boolean> getStatus() {
@@ -29,5 +40,4 @@ public class FeatureStatusTracker {
     public static boolean hasEnabledFeatures() {
         return !features.isEmpty();
     }
-
 }

--- a/app/src/main/java/ps/reso/instaeclipse/utils/version/VersionCheckUtility.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/version/VersionCheckUtility.java
@@ -5,6 +5,8 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.AsyncTask;
 
+import ps.reso.instaeclipse.R;
+
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.gson.Gson;
 
@@ -62,25 +64,21 @@ public class VersionCheckUtility {
 
     private static void showUpdateDialog(Context context, String updateUrl, String newVersion) {
         new MaterialAlertDialogBuilder(context)
-                .setTitle("Update Available")
-                .setMessage("A new version (" + newVersion + ") is available. Would you like to update now?")
-                .setPositiveButton("Update", (dialogInterface, which) -> {
-                    // Open the update URL in the browser
+                .setTitle(context.getString(R.string.ig_update_title))
+                .setMessage(context.getString(R.string.ig_update_message, newVersion))
+                .setPositiveButton(context.getString(R.string.ig_update_button), (dialogInterface, which) -> {
                     Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(updateUrl));
                     context.startActivity(browserIntent);
                 })
-                .setNegativeButton("Later", (dialogInterface, which) -> {
-                    // Dismiss the dialog
-                    dialogInterface.dismiss();
-                })
+                .setNegativeButton(context.getString(R.string.ig_update_later), (dialogInterface, which) -> dialogInterface.dismiss())
                 .show();
     }
 
     private static void showErrorDialog(Context context) {
         new MaterialAlertDialogBuilder(context)
-                .setTitle("Error")
-                .setMessage("Failed to check for updates. Please try again later.")
-                .setPositiveButton("OK", (dialogInterface, which) -> dialogInterface.dismiss())
+                .setTitle(context.getString(R.string.ig_dialog_error))
+                .setMessage(context.getString(R.string.ig_update_error_message))
+                .setPositiveButton(context.getString(R.string.ig_dialog_ok), (dialogInterface, which) -> dialogInterface.dismiss())
                 .show();
     }
 }

--- a/app/src/main/java/ps/reso/instaeclipse/utils/version/VersionCheckUtility.java
+++ b/app/src/main/java/ps/reso/instaeclipse/utils/version/VersionCheckUtility.java
@@ -15,7 +15,7 @@ import java.net.URL;
 
 public class VersionCheckUtility {
 
-    private static final String CURRENT_VERSION = "0.5.0"; // Current version
+    private static final String CURRENT_VERSION = "0.5.1"; // Current version
     private static final String VERSION_CHECK_URL = "https://raw.githubusercontent.com/ReSo7200/InstaEclipse/refs/heads/main/version.json"; // JSON URL
 
     public static void checkForUpdates(Context context) {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -120,7 +120,7 @@
     <string name="ig_dialog_menu_dev_options">خيارات المطور 🎛</string>
     <string name="ig_dialog_menu_ghost_settings">إعدادات وضع الشبح 👻</string>
     <string name="ig_dialog_menu_ad_analytics">حظر الإعلانات/التحليلات 🛡</string>
-    <string name="ig_dialog_menu_clean_feed">✨ خلاصة نظيفة</string>
+    <string name="ig_dialog_menu_clean_feed">محتوى رئيسي نظيف ✨</string>
     <string name="ig_dialog_menu_distraction_free">إنستغرام بلا إلهاء 🧘</string>
     <string name="ig_dialog_menu_misc">ميزات متنوعة ⚙</string>
     <string name="ig_dialog_menu_downloader">التنزيل 📥</string>
@@ -317,4 +317,16 @@
     <string name="ig_mention_subtitle">%1$d إشارة • انقر للنسخ</string>
     <string name="ig_mention_no_mentions">لم يتم العثور على إشارات في هذه القصة</string>
     <string name="ig_mention_copy_all">نسخ الكل</string>
+
+    <!-- Toast: Downloader (service) -->
+    <string name="ig_toast_no_download_folder">لم يتم تعيين مجلد للتنزيل</string>
+    <string name="ig_toast_file_saved">تم الحفظ: %1$s</string>
+    <string name="ig_toast_features_loaded">InstaEclipse جاهز 🎯</string>
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">تحديث متاح</string>
+    <string name="ig_update_message">إصدار جديد (%1$s) متاح. هل تريد التحديث الآن؟</string>
+    <string name="ig_update_button">تحديث</string>
+    <string name="ig_update_later">لاحقاً</string>
+    <string name="ig_update_error_message">فشل التحقق من التحديثات. يرجى المحاولة مرة أخرى لاحقاً.</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -203,6 +203,7 @@
     <string name="ig_dialog_misc_view_story_mentions">عرض الإشارات في القصص</string>
     <string name="ig_dialog_misc_disable_discover_people">تعطيل اكتشاف الأشخاص</string>
     <string name="ig_dialog_misc_copy_comment">نسخ التعليق</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">تعطيل النقر المزدوج للإعجاب</string>
 
     <!-- Comment Copy dialog -->
     <string name="ig_comment_copy_title">نسخ التعليق</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -120,6 +120,7 @@
     <string name="ig_dialog_menu_dev_options">خيارات المطور 🎛</string>
     <string name="ig_dialog_menu_ghost_settings">إعدادات وضع الشبح 👻</string>
     <string name="ig_dialog_menu_ad_analytics">حظر الإعلانات/التحليلات 🛡</string>
+    <string name="ig_dialog_menu_clean_feed">✨ خلاصة نظيفة</string>
     <string name="ig_dialog_menu_distraction_free">إنستغرام بلا إلهاء 🧘</string>
     <string name="ig_dialog_menu_misc">ميزات متنوعة ⚙</string>
     <string name="ig_dialog_menu_downloader">التنزيل 📥</string>
@@ -129,6 +130,7 @@
     <string name="ig_dialog_section_dev_options">خيارات المطور 🎛</string>
     <string name="ig_dialog_section_ghost_mode">وضع الشبح 👻</string>
     <string name="ig_dialog_section_ad_analytics">حظر الإعلانات/التحليلات 🛡️</string>
+    <string name="ig_dialog_section_clean_feed">خلاصة نظيفة ✨</string>
     <string name="ig_dialog_section_distraction_free">إنستغرام بلا إلهاء 🧘</string>
     <string name="ig_dialog_section_misc">متنوع ⚙️</string>
     <string name="ig_dialog_section_downloader">التنزيل 📥</string>
@@ -182,6 +184,7 @@
     <string name="ig_dialog_quick_allow_screenshots">تضمين السماح بلقطات الشاشة في الرسائل المباشرة</string>
     <string name="ig_dialog_ad_block_ads">حظر الإعلانات</string>
     <string name="ig_dialog_ad_block_analytics">حظر التحليلات</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">إخفاء الاقتراحات في الخلاصة</string>
     <string name="ig_dialog_ad_disable_tracking">تعطيل روابط التتبع</string>
     <string name="ig_dialog_distraction_extreme_mode">الوضع المتطرف 🔒 (لا رجعة حتى إعادة التثبيت)</string>
     <string name="ig_dialog_distraction_disable_stories">تعطيل القصص</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -184,7 +184,7 @@
     <string name="ig_dialog_quick_allow_screenshots">تضمين السماح بلقطات الشاشة في الرسائل المباشرة</string>
     <string name="ig_dialog_ad_block_ads">حظر الإعلانات</string>
     <string name="ig_dialog_ad_block_analytics">حظر التحليلات</string>
-    <string name="ig_dialog_clean_feed_hide_suggested">إخفاء الاقتراحات في الخلاصة</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">إخفاء الاقتراحات في الفيد</string>
     <string name="ig_dialog_ad_disable_tracking">تعطيل روابط التتبع</string>
     <string name="ig_dialog_distraction_extreme_mode">الوضع المتطرف 🔒 (لا رجعة حتى إعادة التثبيت)</string>
     <string name="ig_dialog_distraction_disable_stories">تعطيل القصص</string>
@@ -226,6 +226,10 @@
     <string name="ig_dialog_about_github">GitHub</string>
     <string name="ig_dialog_about_telegram">Telegram</string>
     <string name="ig_dialog_restart_message">مسح ذاكرة التطبيق وإعادة التشغيل؟ ⚠️</string>
+    <string name="ig_dialog_clear_cache">🔄 مسح الكاش</string>
+    <string name="ig_dialog_section_clear_cache">مسح الكاش</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ سيؤدي هذا إلى إعادة فحص إنستغرام عند التشغيل التالي. سيتم إعادة تشغيل التطبيق.</string>
+    <string name="ig_dialog_clear_cache_now">مسح الكاش وإعادة التشغيل</string>
     <string name="ig_dialog_restart_now">إعادة التشغيل الآن</string>
     <string name="ig_dialog_restart_not_found">تعذر العثور على التطبيق لإعادة التشغيل.</string>
     <string name="ig_dialog_restart_failed">فشلت إعادة التشغيل: %1$s</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -122,6 +122,7 @@
     <string name="ig_dialog_menu_dev_options">🎛 Tərtibatçı Seçimləri</string>
     <string name="ig_dialog_menu_ghost_settings">👻 Kölgə Rejimi Ayarları</string>
     <string name="ig_dialog_menu_ad_analytics">🛡 Reklam/Analitika Bloku</string>
+    <string name="ig_dialog_menu_clean_feed">✨ Təmiz Lent</string>
     <string name="ig_dialog_menu_distraction_free">🧘 Diqqəti Dağıtmayan Instagram</string>
     <string name="ig_dialog_menu_misc">⚙ Müxtəlif Xüsusiyyətlər</string>
     <string name="ig_dialog_menu_downloader">📥 Yükləyici</string>
@@ -131,6 +132,7 @@
     <string name="ig_dialog_section_dev_options">Tərtibatçı Seçimləri 🎛</string>
     <string name="ig_dialog_section_ghost_mode">Kölgə Rejimi 👻</string>
     <string name="ig_dialog_section_ad_analytics">Reklam/Analitika Bloku 🛡️</string>
+    <string name="ig_dialog_section_clean_feed">Təmiz Lent ✨</string>
     <string name="ig_dialog_section_distraction_free">Diqqəti Dağıtmayan Instagram 🧘</string>
     <string name="ig_dialog_section_misc">Müxtəlif ⚙️</string>
     <string name="ig_dialog_section_downloader">Yükləyici 📥</string>
@@ -184,6 +186,7 @@
     <string name="ig_dialog_quick_allow_screenshots">DM-lərdə Ekran Görüntüsünə İcazə Verməyi Daxil Et</string>
     <string name="ig_dialog_ad_block_ads">Reklamları Blokla</string>
     <string name="ig_dialog_ad_block_analytics">Analitikanı Blokla</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">Lentdəki tövsiyələri gizlət</string>
     <string name="ig_dialog_ad_disable_tracking">İzləmə Bağlantılarını Deaktiv Et</string>
     <string name="ig_dialog_distraction_extreme_mode">Ekstremal Rejim 🔒 (Yenidən quraşdıranadək geri alınmaz)</string>
     <string name="ig_dialog_distraction_disable_stories">Hekayələri Deaktiv Et</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -319,4 +319,16 @@
     <string name="ig_mention_subtitle">%1$d qeyd • kopyalamaq üçün tıkla</string>
     <string name="ig_mention_no_mentions">Bu hekayədə qeyd tapılmadı</string>
     <string name="ig_mention_copy_all">Hamısını Kopyala</string>
+
+    <!-- Toast: Downloader (service) -->
+    <string name="ig_toast_no_download_folder">Yükləmə qovluğu təyin edilməyib</string>
+    <string name="ig_toast_file_saved">Saxlanıldı: %1$s</string>
+    <string name="ig_toast_features_loaded">InstaEclipse yükləndi 🎯</string>
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">Yeniləmə mövcuddur</string>
+    <string name="ig_update_message">Yeni versiya (%1$s) mövcuddur. İndi yeniləmək istəyirsiniz?</string>
+    <string name="ig_update_button">Yenilə</string>
+    <string name="ig_update_later">Sonra</string>
+    <string name="ig_update_error_message">Yeniləmələri yoxlamaq mümkün olmadı. Zəhmət olmasa sonra yenidən cəhd edin.</string>
 </resources>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -228,6 +228,10 @@
     <string name="ig_dialog_about_github">GitHub</string>
     <string name="ig_dialog_about_telegram">Telegram</string>
     <string name="ig_dialog_restart_message">⚠️ Tətbiqin keşini təmizlə və yenidən başlat?</string>
+    <string name="ig_dialog_clear_cache">🔄 Hook Önbelleğini Temizle</string>
+    <string name="ig_dialog_section_clear_cache">Hook Önbelleğini Temizle</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ Bu, InstaEclipse-in növbəti işə salınmada Instagram-ı yenidən skan etməsinə məcbur edəcək. Tətbiq yenidən başlayacaq.</string>
+    <string name="ig_dialog_clear_cache_now">Önbelleği Temizle və Yenidən Başlat</string>
     <string name="ig_dialog_restart_now">İndi Yenidən Başlat</string>
     <string name="ig_dialog_restart_not_found">Yenidən başlatmaq üçün tətbiq tapılmadı.</string>
     <string name="ig_dialog_restart_failed">Yenidən başlatma uğursuz oldu: %1$s</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -205,6 +205,7 @@
     <string name="ig_dialog_misc_view_story_mentions">Hekayə Qeydlərini Gör</string>
     <string name="ig_dialog_misc_disable_discover_people">Tanış Tapma Xüsusiyyətini Deaktiv Et</string>
     <string name="ig_dialog_misc_copy_comment">Şərhi Kopyala</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">İkiqat toxunuşla bəyənməni deaktiv et</string>
 
     <!-- Comment Copy dialog -->
     <string name="ig_comment_copy_title">Şərhi Kopyala</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -127,6 +127,7 @@
     <string name="ig_dialog_menu_dev_options">🎛 Entwickleroptionen</string>
     <string name="ig_dialog_menu_ghost_settings">👻 Geistermodus-Einstellungen</string>
     <string name="ig_dialog_menu_ad_analytics">🛡 Werbung/Analytics blockieren</string>
+    <string name="ig_dialog_menu_clean_feed">✨ Sauberer Feed</string>
     <string name="ig_dialog_menu_distraction_free">🧘 Ablenkungsfreies Instagram</string>
     <string name="ig_dialog_menu_misc">⚙ Weitere Funktionen</string>
     <string name="ig_dialog_menu_downloader">📥 Downloader</string>
@@ -136,6 +137,7 @@
     <string name="ig_dialog_section_dev_options">Entwickleroptionen 🎛</string>
     <string name="ig_dialog_section_ghost_mode">Geistermodus 👻</string>
     <string name="ig_dialog_section_ad_analytics">Werbung/Analytics blockieren 🛡️</string>
+    <string name="ig_dialog_section_clean_feed">Sauberer Feed ✨</string>
     <string name="ig_dialog_section_distraction_free">Ablenkungsfreies Instagram 🧘</string>
     <string name="ig_dialog_section_misc">Sonstiges ⚙️</string>
     <string name="ig_dialog_section_downloader">Downloader 📥</string>
@@ -189,6 +191,7 @@
     <string name="ig_dialog_quick_allow_screenshots">Screenshots in DMs erlauben einschließen</string>
     <string name="ig_dialog_ad_block_ads">Werbung blockieren</string>
     <string name="ig_dialog_ad_block_analytics">Analytics blockieren</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">Vorschläge im Feed ausblenden</string>
     <string name="ig_dialog_ad_disable_tracking">Tracking-Links deaktivieren</string>
     <string name="ig_dialog_distraction_extreme_mode">Extremmodus 🔒 (Nicht rückgängig bis zur Neuinstallation)</string>
     <string name="ig_dialog_distraction_disable_stories">Stories deaktivieren</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -210,6 +210,7 @@
     <string name="ig_dialog_misc_view_story_mentions">Story-Erwähnungen anzeigen</string>
     <string name="ig_dialog_misc_disable_discover_people">„Menschen entdecken" deaktivieren</string>
     <string name="ig_dialog_misc_copy_comment">Kommentar kopieren</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">Doppeltippen zum Liken deaktivieren</string>
 
     <!-- Comment Copy dialog -->
     <string name="ig_comment_copy_title">Kommentar kopieren</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -325,4 +325,16 @@
     <string name="ig_mention_no_mentions">Keine Erwähnungen in dieser Story gefunden</string>
     <string name="ig_mention_copy_all">Alle kopieren</string>
 
+    <!-- Toast: Downloader (service) -->
+    <string name="ig_toast_no_download_folder">Kein Download-Ordner festgelegt</string>
+    <string name="ig_toast_file_saved">Gespeichert: %1$s</string>
+    <string name="ig_toast_features_loaded">InstaEclipse geladen 🎯</string>
+
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">Update verfügbar</string>
+    <string name="ig_update_message">Eine neue Version (%1$s) ist verfügbar. Jetzt aktualisieren?</string>
+    <string name="ig_update_button">Aktualisieren</string>
+    <string name="ig_update_later">Später</string>
+    <string name="ig_update_error_message">Update-Prüfung fehlgeschlagen. Bitte später erneut versuchen.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -233,6 +233,10 @@
     <string name="ig_dialog_about_github">GitHub</string>
     <string name="ig_dialog_about_telegram">Telegram</string>
     <string name="ig_dialog_restart_message">⚠️ App-Cache leeren und neu starten?</string>
+    <string name="ig_dialog_clear_cache">🔄 Hooks-Cache leeren</string>
+    <string name="ig_dialog_section_clear_cache">Hooks-Cache leeren</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ Dies zwingt InstaEclipse beim nächsten Start, Instagram erneut zu scannen. Die App wird neu gestartet.</string>
+    <string name="ig_dialog_clear_cache_now">Cache leeren &amp; neu starten</string>
     <string name="ig_dialog_restart_now">Jetzt neu starten</string>
     <string name="ig_dialog_restart_not_found">Die App zum Neustart konnte nicht gefunden werden.</string>
     <string name="ig_dialog_restart_failed">Neustart fehlgeschlagen: %1$s</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -242,6 +242,7 @@
     <string name="ig_dialog_misc_view_story_mentions">Προβολή Αναφορών Story</string>
     <string name="ig_dialog_misc_disable_discover_people">Απενεργοποίηση Προτάσεων Χρηστών</string>
     <string name="ig_dialog_misc_copy_comment">Αντιγραφή Σχολίου</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">Απενεργοποίηση διπλού αγγίγματος για Like</string>
 
     <!-- Comment Copy dialog -->
     <string name="ig_comment_copy_title">Αντιγραφή Σχολίου</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -351,4 +351,16 @@
     <string name="ig_mention_no_mentions">Δεν βρέθηκαν αναφορές σε αυτή την ιστορία</string>
     <string name="ig_mention_copy_all">Αντιγραφή Όλων</string>
 
+    <!-- Toast: Downloader (service) -->
+    <string name="ig_toast_no_download_folder">Δεν έχει οριστεί φάκελος λήψεων</string>
+    <string name="ig_toast_file_saved">Αποθηκεύτηκε: %1$s</string>
+    <string name="ig_toast_features_loaded">Το InstaEclipse φορτώθηκε 🎯</string>
+
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">Διαθέσιμη ενημέρωση</string>
+    <string name="ig_update_message">Μια νέα έκδοση (%1$s) είναι διαθέσιμη. Θέλετε να ενημερώσετε τώρα;</string>
+    <string name="ig_update_button">Ενημέρωση</string>
+    <string name="ig_update_later">Αργότερα</string>
+    <string name="ig_update_error_message">Αποτυχία ελέγχου ενημερώσεων. Δοκιμάστε ξανά αργότερα.</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -145,6 +145,7 @@
     <string name="ig_dialog_menu_dev_options">🎛 Επιλογές Προγραμματιστών</string>
     <string name="ig_dialog_menu_ghost_settings">👻 Ρυθμίσεις Αόρατης Λειτουργίας</string>
     <string name="ig_dialog_menu_ad_analytics">🛡 Αποκλεισμός Διαφημίσεων/Αναλυτικών</string>
+    <string name="ig_dialog_menu_clean_feed">✨ Καθαρό Feed</string>
     <string name="ig_dialog_menu_distraction_free">🧘 Instagram Χωρίς Περισπασμούς</string>
     <string name="ig_dialog_menu_misc">⚙ Διάφορες Λειτουργίες</string>
     <string name="ig_dialog_menu_downloader">📥 Λήψη</string>
@@ -156,6 +157,7 @@
     <string name="ig_dialog_section_dev_options">Επιλογές Προγραμματιστών 🎛</string>
     <string name="ig_dialog_section_ghost_mode">Αόρατη Λειτουργία 👻</string>
     <string name="ig_dialog_section_ad_analytics">Αποκλεισμός Διαφημίσεων/Αναλυτικών 🛡️</string>
+    <string name="ig_dialog_section_clean_feed">Καθαρό Feed ✨</string>
     <string name="ig_dialog_section_distraction_free">Instagram Χωρίς Περισπασμούς 🧘</string>
     <string name="ig_dialog_section_misc">Διάφορα ⚙️</string>
     <string name="ig_dialog_section_downloader">Λήψη 📥</string>
@@ -217,6 +219,7 @@
     <!-- Ad / Analytics options -->
     <string name="ig_dialog_ad_block_ads">Αποκλεισμός Διαφημίσεων</string>
     <string name="ig_dialog_ad_block_analytics">Αποκλεισμός Αναλυτικών</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">Απόκρυψη προτάσεων στο feed</string>
     <string name="ig_dialog_ad_disable_tracking">Απενεργοποίηση Συνδέσμων Παρακολούθησης</string>
 
     <!-- Distraction-Free options -->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -2,7 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- app wide -->
     <string name="app_name">InstaEclipse</string>
-    <string name="version" translatable="false">v0.5 Beta</string>
+    <string name="version" translatable="false">v0.5.1 Beta</string>
     <string name="home">Αρχική</string>
     <string name="features">Λειτουργίες</string>
     <string name="help">Βοήθεια</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -274,6 +274,10 @@
 
     <!-- Restart -->
     <string name="ig_dialog_restart_message">⚠️ Εκκαθάριση cache εφαρμογής και επανεκκίνηση;</string>
+    <string name="ig_dialog_clear_cache">🔄 Εκκαθάριση Cache Hooks</string>
+    <string name="ig_dialog_section_clear_cache">Εκκαθάριση Cache Hooks</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ Αυτό θα αναγκάσει το InstaEclipse να επανασαρώσει το Instagram κατά την επόμενη εκκίνηση. Η εφαρμογή θα επανεκκινηθεί.</string>
+    <string name="ig_dialog_clear_cache_now">Εκκαθάριση Cache &amp; Επανεκκίνηση</string>
     <string name="ig_dialog_restart_now">Επανεκκίνηση Τώρα</string>
     <string name="ig_dialog_restart_not_found">Αδύνατη εύρεση εφαρμογής για επανεκκίνηση.</string>
     <string name="ig_dialog_restart_failed">Αποτυχία επανεκκίνησης: %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -124,6 +124,7 @@
     <string name="ig_dialog_menu_dev_options">🎛 Opciones de desarrollador</string>
     <string name="ig_dialog_menu_ghost_settings">👻 Configuración del modo fantasma</string>
     <string name="ig_dialog_menu_ad_analytics">🛡 Bloqueo de anuncios/analíticas</string>
+    <string name="ig_dialog_menu_clean_feed">✨ Feed limpio</string>
     <string name="ig_dialog_menu_distraction_free">🧘 Instagram sin distracciones</string>
     <string name="ig_dialog_menu_misc">⚙ Funciones adicionales</string>
     <string name="ig_dialog_menu_downloader">📥 Descargador</string>
@@ -133,6 +134,7 @@
     <string name="ig_dialog_section_dev_options">Opciones de desarrollador 🎛</string>
     <string name="ig_dialog_section_ghost_mode">Modo fantasma 👻</string>
     <string name="ig_dialog_section_ad_analytics">Bloqueo de anuncios/analíticas 🛡️</string>
+    <string name="ig_dialog_section_clean_feed">Feed limpio ✨</string>
     <string name="ig_dialog_section_distraction_free">Instagram sin distracciones 🧘</string>
     <string name="ig_dialog_section_misc">Miscelánea ⚙️</string>
     <string name="ig_dialog_section_downloader">Descargador 📥</string>
@@ -186,6 +188,7 @@
     <string name="ig_dialog_quick_allow_screenshots">Incluir permitir capturas en mensajes directos</string>
     <string name="ig_dialog_ad_block_ads">Bloquear anuncios</string>
     <string name="ig_dialog_ad_block_analytics">Bloquear analíticas</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">Ocultar sugerencias en el feed</string>
     <string name="ig_dialog_ad_disable_tracking">Desactivar enlaces de rastreo</string>
     <string name="ig_dialog_distraction_extreme_mode">Modo extremo 🔒 (Irreversible hasta reinstalar)</string>
     <string name="ig_dialog_distraction_disable_stories">Desactivar historias</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -321,4 +321,16 @@
     <string name="ig_mention_subtitle">%1$d mención(es) • toca para copiar</string>
     <string name="ig_mention_no_mentions">No se encontraron menciones en esta historia</string>
     <string name="ig_mention_copy_all">Copiar todo</string>
+
+    <!-- Toast: Downloader (service) -->
+    <string name="ig_toast_no_download_folder">No se ha definido la carpeta de descarga</string>
+    <string name="ig_toast_file_saved">Guardado: %1$s</string>
+    <string name="ig_toast_features_loaded">InstaEclipse cargado 🎯</string>
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">Actualización disponible</string>
+    <string name="ig_update_message">Una nueva versión (%1$s) está disponible. ¿Deseas actualizar ahora?</string>
+    <string name="ig_update_button">Actualizar</string>
+    <string name="ig_update_later">Más tarde</string>
+    <string name="ig_update_error_message">Error al comprobar actualizaciones. Inténtalo de nuevo más tarde.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -207,6 +207,7 @@
     <string name="ig_dialog_misc_view_story_mentions">Ver menciones en historias</string>
     <string name="ig_dialog_misc_disable_discover_people">Desactivar descubrir personas</string>
     <string name="ig_dialog_misc_copy_comment">Copiar comentario</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">Desactivar doble toque para dar like</string>
 
     <!-- Comment Copy dialog -->
     <string name="ig_comment_copy_title">Copiar comentario</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -230,6 +230,10 @@
     <string name="ig_dialog_about_github">GitHub</string>
     <string name="ig_dialog_about_telegram">Telegram</string>
     <string name="ig_dialog_restart_message">⚠️ ¿Limpiar caché de la app y reiniciar?</string>
+    <string name="ig_dialog_clear_cache">🔄 Borrar Caché de Hooks</string>
+    <string name="ig_dialog_section_clear_cache">Borrar Caché de Hooks</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ Esto obligará a InstaEclipse a re-escanear Instagram en el próximo inicio. La app se reiniciará.</string>
+    <string name="ig_dialog_clear_cache_now">Borrar Caché &amp; Reiniciar</string>
     <string name="ig_dialog_restart_now">Reiniciar ahora</string>
     <string name="ig_dialog_restart_not_found">No se pudo encontrar la aplicación para reiniciar.</string>
     <string name="ig_dialog_restart_failed">Error al reiniciar: %1$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -241,6 +241,7 @@
     <string name="ig_dialog_misc_view_story_mentions">Voir Mentions de Story</string>
     <string name="ig_dialog_misc_disable_discover_people">Désactiver Suggestions de personnes</string>
     <string name="ig_dialog_misc_copy_comment">Copier Commentaire</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">Désactiver le double tap pour liker</string>
 
     <!-- Comment Copy dialog -->
     <string name="ig_comment_copy_title">Copier Commentaire</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -144,6 +144,7 @@
     <string name="ig_dialog_menu_dev_options">🎛 Options Développeurs</string>
     <string name="ig_dialog_menu_ghost_settings">👻 Paramètres Mode Fantôme</string>
     <string name="ig_dialog_menu_ad_analytics">🛡 Blocage Pubs/Analytics</string>
+    <string name="ig_dialog_menu_clean_feed">✨ Fil propre</string>
     <string name="ig_dialog_menu_distraction_free">🧘 Instagram Sans Distractions</string>
     <string name="ig_dialog_menu_misc">⚙ Fonctions Diverses</string>
     <string name="ig_dialog_menu_downloader">📥 Téléchargeur</string>
@@ -155,6 +156,7 @@
     <string name="ig_dialog_section_dev_options">Options Développeurs 🎛</string>
     <string name="ig_dialog_section_ghost_mode">Mode Fantôme 👻</string>
     <string name="ig_dialog_section_ad_analytics">Blocage Pubs/Analytics 🛡️</string>
+    <string name="ig_dialog_section_clean_feed">Fil propre ✨</string>
     <string name="ig_dialog_section_distraction_free">Instagram Sans Distractions 🧘</string>
     <string name="ig_dialog_section_misc">Divers ⚙️</string>
     <string name="ig_dialog_section_downloader">Téléchargeur 📥</string>
@@ -216,6 +218,7 @@
     <!-- Ad / Analytics options -->
     <string name="ig_dialog_ad_block_ads">Bloquer les pubs</string>
     <string name="ig_dialog_ad_block_analytics">Bloquer les analytics</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">Masquer les suggestions dans le fil</string>
     <string name="ig_dialog_ad_disable_tracking">Désactiver liens de suivi</string>
 
     <!-- Distraction-Free options -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,7 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- app wide -->
     <string name="app_name">InstaEclipse</string>
-    <string name="version" translatable="false">v0.5 Beta</string>
+    <string name="version" translatable="false">v0.5.1 Beta</string>
     <string name="home">Menu</string>
     <string name="features">Fonctionnalités</string>
     <string name="help">Aide</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -273,6 +273,10 @@
 
     <!-- Restart -->
     <string name="ig_dialog_restart_message">⚠️ Vider le cache et redémarrer ?</string>
+    <string name="ig_dialog_clear_cache">🔄 Vider le Cache des Hooks</string>
+    <string name="ig_dialog_section_clear_cache">Vider le Cache des Hooks</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ Cela forcera InstaEclipse à re-scanner Instagram au prochain démarrage. L\'application redémarrera.</string>
+    <string name="ig_dialog_clear_cache_now">Vider le Cache &amp; Redémarrer</string>
     <string name="ig_dialog_restart_now">Redémarrer Maintenant</string>
     <string name="ig_dialog_restart_not_found">Impossible de trouver l\'app pour redémarrer.</string>
     <string name="ig_dialog_restart_failed">Échec du redémarrage : %1$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -350,4 +350,16 @@
     <string name="ig_mention_no_mentions">Aucune mention trouvée dans cette story</string>
     <string name="ig_mention_copy_all">Tout copier</string>
 
+    <!-- Toast: Downloader (service) -->
+    <string name="ig_toast_no_download_folder">Aucun dossier de téléchargement défini</string>
+    <string name="ig_toast_file_saved">Enregistré : %1$s</string>
+    <string name="ig_toast_features_loaded">InstaEclipse chargé 🎯</string>
+
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">Mise à jour disponible</string>
+    <string name="ig_update_message">Une nouvelle version (%1$s) est disponible. Voulez-vous mettre à jour maintenant ?</string>
+    <string name="ig_update_button">Mettre à jour</string>
+    <string name="ig_update_later">Plus tard</string>
+    <string name="ig_update_error_message">Échec de la vérification des mises à jour. Réessayez plus tard.</string>
 </resources>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -144,6 +144,7 @@
     <string name="ig_dialog_menu_dev_options">🎛 הגדרות מפתחים</string>
     <string name="ig_dialog_menu_ghost_settings">👻 הגדרות מצב רפאים</string>
     <string name="ig_dialog_menu_ad_analytics">🛡 חסימת פרסומות/אנליטיקות</string>
+    <string name="ig_dialog_menu_clean_feed">✨ עדכון נקי</string>
     <string name="ig_dialog_menu_distraction_free">🧘 אינסטגרם ללא הסחות דעת</string>
     <string name="ig_dialog_menu_misc">⚙ תכונות נוספות</string>
     <string name="ig_dialog_menu_downloader">📥 הורדה</string>
@@ -155,6 +156,7 @@
     <string name="ig_dialog_section_dev_options">הגדרות מפתחים 🎛</string>
     <string name="ig_dialog_section_ghost_mode">מצב רפאים 👻</string>
     <string name="ig_dialog_section_ad_analytics">חסימת פרסומות/אנליטיקות 🛡️</string>
+    <string name="ig_dialog_section_clean_feed">עדכון נקי ✨</string>
     <string name="ig_dialog_section_distraction_free">אינסטגרם ללא הסחות דעת 🧘</string>
     <string name="ig_dialog_section_misc">שונות ⚙️</string>
     <string name="ig_dialog_section_downloader">הורדה 📥</string>
@@ -216,6 +218,7 @@
     <!-- Ad / Analytics options -->
     <string name="ig_dialog_ad_block_ads">חסום פרסומות</string>
     <string name="ig_dialog_ad_block_analytics">חסום אנליטיקות</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">הסתר הצעות בעדכון</string>
     <string name="ig_dialog_ad_disable_tracking">השבת קישורי מעקב</string>
 
     <!-- Distraction-Free options -->

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -241,6 +241,7 @@
     <string name="ig_dialog_misc_view_story_mentions">צפה באזכורי סטורי</string>
     <string name="ig_dialog_misc_disable_discover_people">השבת הצעות אנשים</string>
     <string name="ig_dialog_misc_copy_comment">העתק תגובה</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">השבת הקשה כפולה לסימון לייק</string>
 
     <!-- Comment Copy dialog -->
     <string name="ig_comment_copy_title">העתק תגובה</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -1,7 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- app wide -->
     <string name="app_name">InstaEclipse</string>
-    <string name="version" translatable="false">v0.5 Beta</string>
+    <string name="version" translatable="false">v0.5.1 Beta</string>
     <string name="home">דף הבית</string>
     <string name="features">תכונות</string>
     <string name="help">עזרה</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -273,6 +273,10 @@
 
     <!-- Restart -->
     <string name="ig_dialog_restart_message">⚠️ נקה cache ואתחל?</string>
+    <string name="ig_dialog_clear_cache">🔄 נקה מטמון Hooks</string>
+    <string name="ig_dialog_section_clear_cache">נקה מטמון Hooks</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ פעולה זו תאלץ את InstaEclipse לסרוק מחדש את אינסטגרם בהפעלה הבאה. האפליקציה תופעל מחדש.</string>
+    <string name="ig_dialog_clear_cache_now">נקה מטמון &amp; הפעל מחדש</string>
     <string name="ig_dialog_restart_now">אתחל עכשיו</string>
     <string name="ig_dialog_restart_not_found">לא נמצאה האפליקציה לאתחול.</string>
     <string name="ig_dialog_restart_failed">האתחול נכשל: %1$s</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -350,4 +350,16 @@
     <string name="ig_mention_no_mentions">לא נמצאו אזכורים בסטורי זה</string>
     <string name="ig_mention_copy_all">העתק הכל</string>
 
+    <!-- Toast: Downloader (service) -->
+    <string name="ig_toast_no_download_folder">לא הוגדרה תיקיית הורדות</string>
+    <string name="ig_toast_file_saved">נשמר: %1$s</string>
+    <string name="ig_toast_features_loaded">InstaEclipse נטען 🎯</string>
+
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">עדכון זמין</string>
+    <string name="ig_update_message">גרסה חדשה (%1$s) זמינה. האם ברצונך לעדכן עכשיו?</string>
+    <string name="ig_update_button">עדכן</string>
+    <string name="ig_update_later">מאוחר יותר</string>
+    <string name="ig_update_error_message">בדיקת עדכונים נכשלה. נסה שוב מאוחר יותר.</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -241,6 +241,7 @@
     <string name="ig_dialog_misc_view_story_mentions">Lihat Sebutan Story</string>
     <string name="ig_dialog_misc_disable_discover_people">Nonaktifkan Temukan Orang</string>
     <string name="ig_dialog_misc_copy_comment">Salin Komentar</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">Nonaktifkan Ketuk Dua Kali untuk Suka</string>
 
     <!-- Comment Copy dialog -->
     <string name="ig_comment_copy_title">Salin Komentar</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -144,6 +144,7 @@
     <string name="ig_dialog_menu_dev_options">🎛 Opsi Pengembang</string>
     <string name="ig_dialog_menu_ghost_settings">👻 Pengaturan Mode Hantu</string>
     <string name="ig_dialog_menu_ad_analytics">🛡 Blokir Iklan/Analitik</string>
+    <string name="ig_dialog_menu_clean_feed">✨ Feed Bersih</string>
     <string name="ig_dialog_menu_distraction_free">🧘 Instagram Bebas Gangguan</string>
     <string name="ig_dialog_menu_misc">⚙ Fitur Lainnya</string>
     <string name="ig_dialog_menu_downloader">📥 Pengunduh</string>
@@ -155,6 +156,7 @@
     <string name="ig_dialog_section_dev_options">Opsi Pengembang 🎛</string>
     <string name="ig_dialog_section_ghost_mode">Mode Hantu 👻</string>
     <string name="ig_dialog_section_ad_analytics">Blokir Iklan/Analitik 🛡️</string>
+    <string name="ig_dialog_section_clean_feed">Feed Bersih ✨</string>
     <string name="ig_dialog_section_distraction_free">Instagram Bebas Gangguan 🧘</string>
     <string name="ig_dialog_section_misc">Lainnya ⚙️</string>
     <string name="ig_dialog_section_downloader">Pengunduh 📥</string>
@@ -216,6 +218,7 @@
     <!-- Ad / Analytics options -->
     <string name="ig_dialog_ad_block_ads">Blokir Iklan</string>
     <string name="ig_dialog_ad_block_analytics">Blokir Analitik</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">Sembunyikan saran di feed</string>
     <string name="ig_dialog_ad_disable_tracking">Nonaktifkan Tautan Pelacakan</string>
 
     <!-- Distraction-Free options -->

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -350,4 +350,16 @@
     <string name="ig_mention_no_mentions">Tidak ada sebutan ditemukan dalam story ini</string>
     <string name="ig_mention_copy_all">Salin Semua</string>
 
+    <!-- Toast: Downloader (service) -->
+    <string name="ig_toast_no_download_folder">Folder unduhan belum diatur</string>
+    <string name="ig_toast_file_saved">Tersimpan: %1$s</string>
+    <string name="ig_toast_features_loaded">InstaEclipse dimuat 🎯</string>
+
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">Pembaruan Tersedia</string>
+    <string name="ig_update_message">Versi baru (%1$s) tersedia. Apakah Anda ingin memperbarui sekarang?</string>
+    <string name="ig_update_button">Perbarui</string>
+    <string name="ig_update_later">Nanti</string>
+    <string name="ig_update_error_message">Gagal memeriksa pembaruan. Silakan coba lagi nanti.</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -273,6 +273,10 @@
 
     <!-- Restart -->
     <string name="ig_dialog_restart_message">⚠️ Hapus cache aplikasi dan mulai ulang?</string>
+    <string name="ig_dialog_clear_cache">🔄 Bersihkan Cache Hooks</string>
+    <string name="ig_dialog_section_clear_cache">Bersihkan Cache Hooks</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ Ini akan memaksa InstaEclipse untuk memindai ulang Instagram saat peluncuran berikutnya. Aplikasi akan dimulai ulang.</string>
+    <string name="ig_dialog_clear_cache_now">Bersihkan Cache &amp; Mulai Ulang</string>
     <string name="ig_dialog_restart_now">Mulai Ulang Sekarang</string>
     <string name="ig_dialog_restart_not_found">Tidak dapat menemukan aplikasi untuk dimulai ulang.</string>
     <string name="ig_dialog_restart_failed">Mulai ulang gagal: %1$s</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1,7 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- app wide -->
     <string name="app_name">InstaEclipse</string>
-    <string name="version" translatable="false">v0.5 Beta</string>
+    <string name="version" translatable="false">v0.5.1 Beta</string>
     <string name="home">Beranda</string>
     <string name="features">Fitur</string>
     <string name="help">Bantuan</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -144,6 +144,7 @@
     <string name="ig_dialog_menu_dev_options">🎛 הגדרות מפתחים</string>
     <string name="ig_dialog_menu_ghost_settings">👻 הגדרות מצב רפאים</string>
     <string name="ig_dialog_menu_ad_analytics">🛡 חסימת פרסומות/אנליטיקות</string>
+    <string name="ig_dialog_menu_clean_feed">✨ עדכון נקי</string>
     <string name="ig_dialog_menu_distraction_free">🧘 אינסטגרם ללא הסחות דעת</string>
     <string name="ig_dialog_menu_misc">⚙ תכונות נוספות</string>
     <string name="ig_dialog_menu_downloader">📥 הורדה</string>
@@ -155,6 +156,7 @@
     <string name="ig_dialog_section_dev_options">הגדרות מפתחים 🎛</string>
     <string name="ig_dialog_section_ghost_mode">מצב רפאים 👻</string>
     <string name="ig_dialog_section_ad_analytics">חסימת פרסומות/אנליטיקות 🛡️</string>
+    <string name="ig_dialog_section_clean_feed">עדכון נקי ✨</string>
     <string name="ig_dialog_section_distraction_free">אינסטגרם ללא הסחות דעת 🧘</string>
     <string name="ig_dialog_section_misc">שונות ⚙️</string>
     <string name="ig_dialog_section_downloader">הורדה 📥</string>
@@ -216,6 +218,7 @@
     <!-- Ad / Analytics options -->
     <string name="ig_dialog_ad_block_ads">חסום פרסומות</string>
     <string name="ig_dialog_ad_block_analytics">חסום אנליטיקות</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">הסתר הצעות בעדכון</string>
     <string name="ig_dialog_ad_disable_tracking">השבת קישורי מעקב</string>
 
     <!-- Distraction-Free options -->

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -241,6 +241,7 @@
     <string name="ig_dialog_misc_view_story_mentions">צפה באזכורי סטורי</string>
     <string name="ig_dialog_misc_disable_discover_people">השבת הצעות אנשים</string>
     <string name="ig_dialog_misc_copy_comment">העתק תגובה</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">השבת הקשה כפולה לסימון לייק</string>
 
     <!-- Comment Copy dialog -->
     <string name="ig_comment_copy_title">העתק תגובה</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1,7 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- app wide -->
     <string name="app_name">InstaEclipse</string>
-    <string name="version" translatable="false">v0.5 Beta</string>
+    <string name="version" translatable="false">v0.5.1 Beta</string>
     <string name="home">דף הבית</string>
     <string name="features">תכונות</string>
     <string name="help">עזרה</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -273,6 +273,10 @@
 
     <!-- Restart -->
     <string name="ig_dialog_restart_message">⚠️ נקה cache ואתחל?</string>
+    <string name="ig_dialog_clear_cache">🔄 נקה מטמון Hooks</string>
+    <string name="ig_dialog_section_clear_cache">נקה מטמון Hooks</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ פעולה זו תאלץ את InstaEclipse לסרוק מחדש את אינסטגרם בהפעלה הבאה. האפליקציה תופעל מחדש.</string>
+    <string name="ig_dialog_clear_cache_now">נקה מטמון &amp; הפעל מחדש</string>
     <string name="ig_dialog_restart_now">אתחל עכשיו</string>
     <string name="ig_dialog_restart_not_found">לא נמצאה האפליקציה לאתחול.</string>
     <string name="ig_dialog_restart_failed">האתחול נכשל: %1$s</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -350,4 +350,16 @@
     <string name="ig_mention_no_mentions">לא נמצאו אזכורים בסטורי זה</string>
     <string name="ig_mention_copy_all">העתק הכל</string>
 
+    <!-- Toast: Downloader (service) -->
+    <string name="ig_toast_no_download_folder">לא הוגדרה תיקיית הורדות</string>
+    <string name="ig_toast_file_saved">נשמר: %1$s</string>
+    <string name="ig_toast_features_loaded">InstaEclipse נטען 🎯</string>
+
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">עדכון זמין</string>
+    <string name="ig_update_message">גרסה חדשה (%1$s) זמינה. האם ברצונך לעדכן עכשיו?</string>
+    <string name="ig_update_button">עדכן</string>
+    <string name="ig_update_later">מאוחר יותר</string>
+    <string name="ig_update_error_message">בדיקת עדכונים נכשלה. נסה שוב מאוחר יותר.</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -227,6 +227,10 @@
     <string name="ig_dialog_about_github">GitHub</string>
     <string name="ig_dialog_about_telegram">Telegram</string>
     <string name="ig_dialog_restart_message">⚠️ Limpar cache da aplicação e reiniciar?</string>
+    <string name="ig_dialog_clear_cache">🔄 Limpar Cache de Hooks</string>
+    <string name="ig_dialog_section_clear_cache">Limpar Cache de Hooks</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ Isso forçará o InstaEclipse a re-escanear o Instagram na próxima inicialização. O app será reiniciado.</string>
+    <string name="ig_dialog_clear_cache_now">Limpar Cache &amp; Reiniciar</string>
     <string name="ig_dialog_restart_now">Reiniciar agora</string>
     <string name="ig_dialog_restart_not_found">Não foi possível encontrar a aplicação para reiniciar.</string>
     <string name="ig_dialog_restart_failed">Falha ao reiniciar: %1$s</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -121,6 +121,7 @@
     <string name="ig_dialog_menu_dev_options">🎛 Opções de desenvolvedor</string>
     <string name="ig_dialog_menu_ghost_settings">👻 Configurações do modo fantasma</string>
     <string name="ig_dialog_menu_ad_analytics">🛡 Bloquear anúncios/análises</string>
+    <string name="ig_dialog_menu_clean_feed">✨ Feed limpo</string>
     <string name="ig_dialog_menu_distraction_free">🧘 Instagram sem distrações</string>
     <string name="ig_dialog_menu_misc">⚙ Funções diversas</string>
     <string name="ig_dialog_menu_downloader">📥 Transferidor</string>
@@ -130,6 +131,7 @@
     <string name="ig_dialog_section_dev_options">Opções de desenvolvedor 🎛</string>
     <string name="ig_dialog_section_ghost_mode">Modo fantasma 👻</string>
     <string name="ig_dialog_section_ad_analytics">Bloquear anúncios/análises 🛡️</string>
+    <string name="ig_dialog_section_clean_feed">Feed limpo ✨</string>
     <string name="ig_dialog_section_distraction_free">Instagram sem distrações 🧘</string>
     <string name="ig_dialog_section_misc">Miscelânea ⚙️</string>
     <string name="ig_dialog_section_downloader">Transferidor 📥</string>
@@ -183,6 +185,7 @@
     <string name="ig_dialog_quick_allow_screenshots">Incluir permitir capturas de ecrã em mensagens diretas</string>
     <string name="ig_dialog_ad_block_ads">Bloquear anúncios</string>
     <string name="ig_dialog_ad_block_analytics">Bloquear análises</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">Ocultar sugestões no feed</string>
     <string name="ig_dialog_ad_disable_tracking">Desativar links de rastreamento</string>
     <string name="ig_dialog_distraction_extreme_mode">Modo extremo 🔒 (Irreversível até reinstalar)</string>
     <string name="ig_dialog_distraction_disable_stories">Desativar stories</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -204,6 +204,7 @@
     <string name="ig_dialog_misc_view_story_mentions">Ver menções em stories</string>
     <string name="ig_dialog_misc_disable_discover_people">Desativar descobrir pessoas</string>
     <string name="ig_dialog_misc_copy_comment">Copiar comentário</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">Desativar toque duplo para curtir</string>
 
     <!-- Comment Copy dialog -->
     <string name="ig_comment_copy_title">Copiar comentário</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -318,4 +318,16 @@
     <string name="ig_mention_subtitle">%1$d menção(ões) • toque para copiar</string>
     <string name="ig_mention_no_mentions">Nenhuma menção encontrada nesta história</string>
     <string name="ig_mention_copy_all">Copiar tudo</string>
+
+    <!-- Toast: Downloader (service) -->
+    <string name="ig_toast_no_download_folder">Nenhuma pasta de transferência definida</string>
+    <string name="ig_toast_file_saved">Guardado: %1$s</string>
+    <string name="ig_toast_features_loaded">InstaEclipse carregado 🎯</string>
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">Atualização disponível</string>
+    <string name="ig_update_message">Uma nova versão (%1$s) está disponível. Deseja atualizar agora?</string>
+    <string name="ig_update_button">Atualizar</string>
+    <string name="ig_update_later">Mais tarde</string>
+    <string name="ig_update_error_message">Falha ao verificar atualizações. Tente novamente mais tarde.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -319,5 +319,16 @@
     <string name="ig_mention_subtitle">%1$d упомин. • нажмите для копирования</string>
     <string name="ig_mention_no_mentions">В этой истории не найдено упоминаний</string>
     <string name="ig_mention_copy_all">Копировать все</string>
-</resources>
 
+    <!-- Toast: Downloader (service) -->
+    <string name="ig_toast_no_download_folder">Папка загрузки не задана</string>
+    <string name="ig_toast_file_saved">Сохранено: %1$s</string>
+    <string name="ig_toast_features_loaded">InstaEclipse загружен 🎯</string>
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">Доступно обновление</string>
+    <string name="ig_update_message">Доступна новая версия (%1$s). Обновить сейчас?</string>
+    <string name="ig_update_button">Обновить</string>
+    <string name="ig_update_later">Позже</string>
+    <string name="ig_update_error_message">Не удалось проверить обновления. Повторите попытку позже.</string>
+</resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -122,6 +122,7 @@
     <string name="ig_dialog_menu_dev_options">🎛 Параметры разработчика</string>
     <string name="ig_dialog_menu_ghost_settings">👻 Настройки режима призрака</string>
     <string name="ig_dialog_menu_ad_analytics">🛡 Блокировка рекламы/аналитики</string>
+    <string name="ig_dialog_menu_clean_feed">✨ Чистая лента</string>
     <string name="ig_dialog_menu_distraction_free">🧘 Instagram без отвлечений</string>
     <string name="ig_dialog_menu_misc">⚙ Прочие функции</string>
     <string name="ig_dialog_menu_downloader">📥 Загрузчик</string>
@@ -131,6 +132,7 @@
     <string name="ig_dialog_section_dev_options">Параметры разработчика 🎛</string>
     <string name="ig_dialog_section_ghost_mode">Режим призрака 👻</string>
     <string name="ig_dialog_section_ad_analytics">Блокировка рекламы/аналитики 🛡️</string>
+    <string name="ig_dialog_section_clean_feed">Чистая лента ✨</string>
     <string name="ig_dialog_section_distraction_free">Instagram без отвлечений 🧘</string>
     <string name="ig_dialog_section_misc">Прочее ⚙️</string>
     <string name="ig_dialog_section_downloader">Загрузчик 📥</string>
@@ -184,6 +186,7 @@
     <string name="ig_dialog_quick_allow_screenshots">Включить разрешение скриншотов в личных сообщениях</string>
     <string name="ig_dialog_ad_block_ads">Блокировать рекламу</string>
     <string name="ig_dialog_ad_block_analytics">Блокировать аналитику</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">Скрыть предложения в ленте</string>
     <string name="ig_dialog_ad_disable_tracking">Отключить ссылки отслеживания</string>
     <string name="ig_dialog_distraction_extreme_mode">Экстремальный режим 🔒 (Необратимо до переустановки)</string>
     <string name="ig_dialog_distraction_disable_stories">Отключить истории</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -205,6 +205,7 @@
     <string name="ig_dialog_misc_view_story_mentions">Просматривать упоминания в историях</string>
     <string name="ig_dialog_misc_disable_discover_people">Отключить рекомендации людей</string>
     <string name="ig_dialog_misc_copy_comment">Копировать комментарий</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">Отключить двойное нажатие для лайка</string>
 
     <!-- Comment Copy dialog -->
     <string name="ig_comment_copy_title">Копировать комментарий</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -228,6 +228,10 @@
     <string name="ig_dialog_about_github">GitHub</string>
     <string name="ig_dialog_about_telegram">Telegram</string>
     <string name="ig_dialog_restart_message">⚠️ Очистить кэш приложения и перезапустить?</string>
+    <string name="ig_dialog_clear_cache">🔄 Очистить кэш хуков</string>
+    <string name="ig_dialog_section_clear_cache">Очистить кэш хуков</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ InstaEclipse повторно просканирует Instagram при следующем запуске. Приложение перезапустится.</string>
+    <string name="ig_dialog_clear_cache_now">Очистить кэш и перезапустить</string>
     <string name="ig_dialog_restart_now">Перезапустить сейчас</string>
     <string name="ig_dialog_restart_not_found">Не удалось найти приложение для перезапуска.</string>
     <string name="ig_dialog_restart_failed">Перезапуск не удался: %1$s</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -121,6 +121,7 @@
     <string name="ig_dialog_menu_dev_options">🎛 Utvecklaralternativ</string>
     <string name="ig_dialog_menu_ghost_settings">👻 Spöklägeinställningar</string>
     <string name="ig_dialog_menu_ad_analytics">🛡 Blockera annonser/analys</string>
+    <string name="ig_dialog_menu_clean_feed">✨ Rent flöde</string>
     <string name="ig_dialog_menu_distraction_free">🧘 Instagram utan distraktioner</string>
     <string name="ig_dialog_menu_misc">⚙ Övriga funktioner</string>
     <string name="ig_dialog_menu_downloader">📥 Nedladdare</string>
@@ -130,6 +131,7 @@
     <string name="ig_dialog_section_dev_options">Utvecklaralternativ 🎛</string>
     <string name="ig_dialog_section_ghost_mode">Spökläge 👻</string>
     <string name="ig_dialog_section_ad_analytics">Blockera annonser/analys 🛡️</string>
+    <string name="ig_dialog_section_clean_feed">Rent flöde ✨</string>
     <string name="ig_dialog_section_distraction_free">Instagram utan distraktioner 🧘</string>
     <string name="ig_dialog_section_misc">Övrigt ⚙️</string>
     <string name="ig_dialog_section_downloader">Nedladdare 📥</string>
@@ -183,6 +185,7 @@
     <string name="ig_dialog_quick_allow_screenshots">Inkludera tillåt skärmdumpar i direktmeddelanden</string>
     <string name="ig_dialog_ad_block_ads">Blockera annonser</string>
     <string name="ig_dialog_ad_block_analytics">Blockera analys</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">Dölj förslag i flödet</string>
     <string name="ig_dialog_ad_disable_tracking">Inaktivera spårningslänkar</string>
     <string name="ig_dialog_distraction_extreme_mode">Extremläge 🔒 (Oåterkalleligt tills ominstallation)</string>
     <string name="ig_dialog_distraction_disable_stories">Inaktivera Stories</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -204,6 +204,7 @@
     <string name="ig_dialog_misc_view_story_mentions">Visa Story-omnämnanden</string>
     <string name="ig_dialog_misc_disable_discover_people">Inaktivera Hitta personer</string>
     <string name="ig_dialog_misc_copy_comment">Kopiera kommentar</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">Inaktivera dubbelklick för att gilla</string>
 
     <!-- Comment Copy dialog -->
     <string name="ig_comment_copy_title">Kopiera kommentar</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -227,6 +227,10 @@
     <string name="ig_dialog_about_github">GitHub</string>
     <string name="ig_dialog_about_telegram">Telegram</string>
     <string name="ig_dialog_restart_message">⚠️ Rensa appcachen och starta om?</string>
+    <string name="ig_dialog_clear_cache">🔄 Rensa Hooks-cache</string>
+    <string name="ig_dialog_section_clear_cache">Rensa Hooks-cache</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ Detta tvingar InstaEclipse att skanna om Instagram vid nästa start. Appen startas om.</string>
+    <string name="ig_dialog_clear_cache_now">Rensa cache &amp; starta om</string>
     <string name="ig_dialog_restart_now">Starta om nu</string>
     <string name="ig_dialog_restart_not_found">Kunde inte hitta appen för omstart.</string>
     <string name="ig_dialog_restart_failed">Omstart misslyckades: %1$s</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -318,4 +318,16 @@
     <string name="ig_mention_subtitle">%1$d omnämnande(n) • tryck för att kopiera</string>
     <string name="ig_mention_no_mentions">Inga omnämnanden hittades i denna story</string>
     <string name="ig_mention_copy_all">Kopiera alla</string>
+
+    <!-- Toast: Downloader (service) -->
+    <string name="ig_toast_no_download_folder">Ingen nedladdningsmapp angiven</string>
+    <string name="ig_toast_file_saved">Sparad: %1$s</string>
+    <string name="ig_toast_features_loaded">InstaEclipse laddad 🎯</string>
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">Uppdatering tillgänglig</string>
+    <string name="ig_update_message">En ny version (%1$s) är tillgänglig. Vill du uppdatera nu?</string>
+    <string name="ig_update_button">Uppdatera</string>
+    <string name="ig_update_later">Senare</string>
+    <string name="ig_update_error_message">Det gick inte att söka efter uppdateringar. Försök igen senare.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -205,6 +205,7 @@
     <string name="ig_dialog_misc_view_story_mentions">Hikaye Bahsetmelerini Görüntüle</string>
     <string name="ig_dialog_misc_disable_discover_people">Kişileri Keşfet\'i Devre Dışı Bırak</string>
     <string name="ig_dialog_misc_copy_comment">Yorumu Kopyala</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">Çift Dokunuşla Beğenmeyi Devre Dışı Bırak</string>
 
     <!-- Comment Copy dialog -->
     <string name="ig_comment_copy_title">Yorumu Kopyala</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -122,6 +122,7 @@
     <string name="ig_dialog_menu_dev_options">🎛 Geliştirici Seçenekleri</string>
     <string name="ig_dialog_menu_ghost_settings">👻 Hayalet Modu Ayarları</string>
     <string name="ig_dialog_menu_ad_analytics">🛡 Reklam/Analitik Engeli</string>
+    <string name="ig_dialog_menu_clean_feed">✨ Temiz Akış</string>
     <string name="ig_dialog_menu_distraction_free">🧘 Dikkat Dağıtıcısız Instagram</string>
     <string name="ig_dialog_menu_misc">⚙ Çeşitli Özellikler</string>
     <string name="ig_dialog_menu_downloader">📥 İndirici</string>
@@ -131,6 +132,7 @@
     <string name="ig_dialog_section_dev_options">Geliştirici Seçenekleri 🎛</string>
     <string name="ig_dialog_section_ghost_mode">Hayalet Modu 👻</string>
     <string name="ig_dialog_section_ad_analytics">Reklam/Analitik Engeli 🛡️</string>
+    <string name="ig_dialog_section_clean_feed">Temiz Akış ✨</string>
     <string name="ig_dialog_section_distraction_free">Dikkat Dağıtıcısız Instagram 🧘</string>
     <string name="ig_dialog_section_misc">Çeşitli ⚙️</string>
     <string name="ig_dialog_section_downloader">İndirici 📥</string>
@@ -184,6 +186,7 @@
     <string name="ig_dialog_quick_allow_screenshots">DM\'lerde Ekran Görüntüsüne İzin Vermeyi Dahil Et</string>
     <string name="ig_dialog_ad_block_ads">Reklamları Engelle</string>
     <string name="ig_dialog_ad_block_analytics">Analitiği Engelle</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">Akıştaki önerileri gizle</string>
     <string name="ig_dialog_ad_disable_tracking">Takip Bağlantılarını Devre Dışı Bırak</string>
     <string name="ig_dialog_distraction_extreme_mode">Aşırı Mod 🔒 (Yeniden yükleyene kadar geri alınamaz)</string>
     <string name="ig_dialog_distraction_disable_stories">Hikayeleri Devre Dışı Bırak</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -228,6 +228,10 @@
     <string name="ig_dialog_about_github">GitHub</string>
     <string name="ig_dialog_about_telegram">Telegram</string>
     <string name="ig_dialog_restart_message">⚠️ Uygulama önbelleğini temizle ve yeniden başlat?</string>
+    <string name="ig_dialog_clear_cache">🔄 Hook Önbelleğini Temizle</string>
+    <string name="ig_dialog_section_clear_cache">Hook Önbelleğini Temizle</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ Bu, InstaEclipse\'i bir sonraki başlatmada Instagram\'ı yeniden taramaya zorlayacak. Uygulama yeniden başlatılacak.</string>
+    <string name="ig_dialog_clear_cache_now">Önbelleği Temizle &amp; Yeniden Başlat</string>
     <string name="ig_dialog_restart_now">Şimdi Yeniden Başlat</string>
     <string name="ig_dialog_restart_not_found">Yeniden başlatmak için uygulama bulunamadı.</string>
     <string name="ig_dialog_restart_failed">Yeniden başlatma başarısız: %1$s</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -319,4 +319,16 @@
     <string name="ig_mention_subtitle">%1$d bahsedilme • kopyalamak için dokun</string>
     <string name="ig_mention_no_mentions">Bu hikayede bahsedilme bulunamadı</string>
     <string name="ig_mention_copy_all">Tümünü Kopyala</string>
+
+    <!-- Toast: Downloader (service) -->
+    <string name="ig_toast_no_download_folder">İndirme klasörü ayarlanmadı</string>
+    <string name="ig_toast_file_saved">Kaydedildi: %1$s</string>
+    <string name="ig_toast_features_loaded">InstaEclipse yüklendi 🎯</string>
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">Güncelleme Mevcut</string>
+    <string name="ig_update_message">Yeni bir sürüm (%1$s) mevcut. Şimdi güncellemek ister misiniz?</string>
+    <string name="ig_update_button">Güncelle</string>
+    <string name="ig_update_later">Daha sonra</string>
+    <string name="ig_update_error_message">Güncellemeler kontrol edilemedi. Lütfen daha sonra tekrar deneyin.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -145,6 +145,7 @@
     <string name="ig_dialog_menu_dev_options">🎛 开发者选项</string>
     <string name="ig_dialog_menu_ghost_settings">👻 幽灵模式设置</string>
     <string name="ig_dialog_menu_ad_analytics">🛡 屏蔽广告/分析</string>
+    <string name="ig_dialog_menu_clean_feed">✨ 纯净动态</string>
     <string name="ig_dialog_menu_distraction_free">🧘 无干扰 Instagram</string>
     <string name="ig_dialog_menu_misc">⚙ 其他功能</string>
     <string name="ig_dialog_menu_downloader">📥 下载器</string>
@@ -156,6 +157,7 @@
     <string name="ig_dialog_section_dev_options">开发者选项 🎛</string>
     <string name="ig_dialog_section_ghost_mode">幽灵模式 👻</string>
     <string name="ig_dialog_section_ad_analytics">屏蔽广告/分析 🛡️</string>
+    <string name="ig_dialog_section_clean_feed">纯净动态 ✨</string>
     <string name="ig_dialog_section_distraction_free">无干扰 Instagram 🧘</string>
     <string name="ig_dialog_section_misc">杂项 ⚙️</string>
     <string name="ig_dialog_section_downloader">下载器 📥</string>
@@ -217,6 +219,7 @@
     <!-- Ad / Analytics options -->
     <string name="ig_dialog_ad_block_ads">屏蔽广告</string>
     <string name="ig_dialog_ad_block_analytics">屏蔽分析</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">隐藏动态中的推荐内容</string>
     <string name="ig_dialog_ad_disable_tracking">禁用追踪链接</string>
 
     <!-- Distraction-Free options -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -351,4 +351,16 @@
     <string name="ig_mention_no_mentions">此限时动态中未找到提及</string>
     <string name="ig_mention_copy_all">复制全部</string>
 
+    <!-- Toast: Downloader (service) -->
+    <string name="ig_toast_no_download_folder">未设置下载文件夹</string>
+    <string name="ig_toast_file_saved">已保存：%1$s</string>
+    <string name="ig_toast_features_loaded">InstaEclipse 已加载 🎯</string>
+
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">有可用更新</string>
+    <string name="ig_update_message">新版本（%1$s）已发布，是否立即更新？</string>
+    <string name="ig_update_button">更新</string>
+    <string name="ig_update_later">稍后</string>
+    <string name="ig_update_error_message">检查更新失败，请稍后重试。</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -274,6 +274,10 @@
 
     <!-- Restart -->
     <string name="ig_dialog_restart_message">⚠️ 清除应用缓存并重启？</string>
+    <string name="ig_dialog_clear_cache">🔄 清除 Hooks 缓存</string>
+    <string name="ig_dialog_section_clear_cache">清除 Hooks 缓存</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ 这将强制 InstaEclipse 在下次启动时重新扫描 Instagram。应用将重新启动。</string>
+    <string name="ig_dialog_clear_cache_now">清除缓存并重启</string>
     <string name="ig_dialog_restart_now">立即重启</string>
     <string name="ig_dialog_restart_not_found">找不到要重启的应用。</string>
     <string name="ig_dialog_restart_failed">重启失败：%1$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -242,6 +242,7 @@
     <string name="ig_dialog_misc_view_story_mentions">查看限时动态提及</string>
     <string name="ig_dialog_misc_disable_discover_people">禁用发现好友</string>
     <string name="ig_dialog_misc_copy_comment">复制评论</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">禁用双击点赞</string>
 
     <!-- Comment Copy dialog -->
     <string name="ig_comment_copy_title">复制评论</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2,7 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!--  app wide  -->
     <string name="app_name">InstaEclipse</string>
-    <string name="version" translatable="false">v0.5 Beta</string>
+    <string name="version" translatable="false">v0.5.1 Beta</string>
     <string name="home">首页</string>
     <string name="features">功能</string>
     <string name="help">帮助</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -129,6 +129,7 @@
     <string name="ig_dialog_menu_dev_options">🎛 開發者選項</string>
     <string name="ig_dialog_menu_ghost_settings">👻 幽靈模式設定</string>
     <string name="ig_dialog_menu_ad_analytics">🛡 廣告/分析封鎖</string>
+    <string name="ig_dialog_menu_clean_feed">✨ 純淨動態</string>
     <string name="ig_dialog_menu_distraction_free">🧘 無干擾 Instagram</string>
     <string name="ig_dialog_menu_misc">⚙ 其他功能</string>
     <string name="ig_dialog_menu_downloader">📥 下載器</string>
@@ -138,6 +139,7 @@
     <string name="ig_dialog_section_dev_options">開發者選項 🎛</string>
     <string name="ig_dialog_section_ghost_mode">幽靈模式 👻</string>
     <string name="ig_dialog_section_ad_analytics">廣告/分析封鎖 🛡️</string>
+    <string name="ig_dialog_section_clean_feed">純淨動態 ✨</string>
     <string name="ig_dialog_section_distraction_free">無干擾 Instagram 🧘</string>
     <string name="ig_dialog_section_misc">其他 ⚙️</string>
     <string name="ig_dialog_section_downloader">下載器 📥</string>
@@ -191,6 +193,7 @@
     <string name="ig_dialog_quick_allow_screenshots">包含允許在私訊中截圖</string>
     <string name="ig_dialog_ad_block_ads">封鎖廣告</string>
     <string name="ig_dialog_ad_block_analytics">封鎖分析</string>
+    <string name="ig_dialog_clean_feed_hide_suggested">隱藏動態中的推薦內容</string>
     <string name="ig_dialog_ad_disable_tracking">停用追蹤連結</string>
     <string name="ig_dialog_distraction_extreme_mode">極端模式 🔒（重新安裝前不可逆）</string>
     <string name="ig_dialog_distraction_disable_stories">停用限時動態</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -235,6 +235,10 @@
     <string name="ig_dialog_about_github">GitHub</string>
     <string name="ig_dialog_about_telegram">Telegram</string>
     <string name="ig_dialog_restart_message">⚠️ 清除應用程式快取並重新啟動？</string>
+    <string name="ig_dialog_clear_cache">🔄 清除 Hooks 快取</string>
+    <string name="ig_dialog_section_clear_cache">清除 Hooks 快取</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ 這將強制 InstaEclipse 在下次啟動時重新掃描 Instagram。應用程式將重新啟動。</string>
+    <string name="ig_dialog_clear_cache_now">清除快取並重啟</string>
     <string name="ig_dialog_restart_now">立即重新啟動</string>
     <string name="ig_dialog_restart_not_found">找不到要重新啟動的應用程式。</string>
     <string name="ig_dialog_restart_failed">重新啟動失敗：%1$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -212,6 +212,7 @@
     <string name="ig_dialog_misc_view_story_mentions">查看限時動態提及</string>
     <string name="ig_dialog_misc_disable_discover_people">停用探索用戶</string>
     <string name="ig_dialog_misc_copy_comment">複製留言</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">停用雙擊點讚</string>
 
     <!-- Comment Copy dialog -->
     <string name="ig_comment_copy_title">複製留言</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -327,4 +327,16 @@
     <string name="ig_mention_no_mentions">此限時動態中未發現提及</string>
     <string name="ig_mention_copy_all">全部複製</string>
 
+    <!-- Toast: Downloader (service) -->
+    <string name="ig_toast_no_download_folder">未設定下載資料夾</string>
+    <string name="ig_toast_file_saved">已儲存：%1$s</string>
+    <string name="ig_toast_features_loaded">InstaEclipse 已載入 🎯</string>
+
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">有可用更新</string>
+    <string name="ig_update_message">新版本（%1$s）已發布，是否立即更新？</string>
+    <string name="ig_update_button">更新</string>
+    <string name="ig_update_later">稍後</string>
+    <string name="ig_update_error_message">檢查更新失敗，請稍後重試。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -342,6 +342,9 @@
     <string name="ig_toast_all_items_saved">All %1$d items saved to InstaEclipse folder</string>
     <string name="ig_toast_items_partial_saved">%1$d of %2$d items saved (%3$d failed)</string>
     <string name="ig_toast_no_reel_url_scroll">No reel URL found — scroll the reel first</string>
+    <string name="ig_toast_no_download_folder">No download folder set</string>
+    <string name="ig_toast_file_saved">Saved: %1$s</string>
+    <string name="ig_toast_features_loaded">InstaEclipse Loaded 🎯</string>
 
     <!-- Downloader carousel UI -->
     <string name="ig_dl_title">Download</string>
@@ -359,5 +362,12 @@
     <string name="ig_mention_subtitle">%1$d mention(s) • tap to copy</string>
     <string name="ig_mention_no_mentions">No mentions found in this story</string>
     <string name="ig_mention_copy_all">Copy All</string>
+
+    <!-- Update check dialog -->
+    <string name="ig_update_title">Update Available</string>
+    <string name="ig_update_message">A new version (%1$s) is available. Would you like to update now?</string>
+    <string name="ig_update_button">Update</string>
+    <string name="ig_update_later">Later</string>
+    <string name="ig_update_error_message">Failed to check for updates. Please try again later.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -255,6 +255,7 @@
     <string name="ig_dialog_misc_view_story_mentions">View Story Mentions</string>
     <string name="ig_dialog_misc_disable_discover_people">Disable Discover People</string>
     <string name="ig_dialog_misc_copy_comment">Copy Comment</string>
+    <string name="ig_dialog_misc_disable_double_tap_like">Disable Double Tap to Like</string>
 
     <!-- Comment Copy dialog (runs in IG process) -->
     <string name="ig_comment_copy_title">Copy Comment</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- app wide -->
     <string name="app_name">InstaEclipse</string>
-    <string name="version" translatable="false">v0.5 Beta</string>
+    <string name="version" translatable="false">v0.5.1 Beta</string>
     <string name="home">Home</string>
     <string name="features">Features</string>
     <string name="help">Help</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,6 +149,7 @@
     <string name="ig_dialog_cancel">Cancel</string>
 
     <!-- Main menu items -->
+    <string name="ig_dialog_menu_clean_feed">✨ Clean Feed</string>
     <string name="ig_dialog_menu_dev_options">🎛 Developer Options</string>
     <string name="ig_dialog_menu_ghost_settings">👻 Ghost Mode Settings</string>
     <string name="ig_dialog_menu_ad_analytics">🛡 Ad/Analytics Block</string>
@@ -160,6 +161,7 @@
     <string name="ig_dialog_menu_restart">🔁 Restart App</string>
 
     <!-- Section titles -->
+    <string name="ig_dialog_section_clean_feed">Clean Feed ✨</string>
     <string name="ig_dialog_section_dev_options">Developer Options 🎛</string>
     <string name="ig_dialog_section_ghost_mode">Ghost Mode 👻</string>
     <string name="ig_dialog_section_ad_analytics">Ad/Analytics Block 🛡️</string>
@@ -236,6 +238,9 @@
     <string name="ig_dialog_distraction_disable_comments">Disable Comments</string>
     <string name="ig_dialog_distraction_extreme_title">Activate Extreme Mode?</string>
     <string name="ig_dialog_distraction_extreme_message">Once activated, you cannot disable Distraction-Free Mode until you reinstall the app. Continue?</string>
+
+    <!-- Clean Feed options -->
+    <string name="ig_dialog_clean_feed_hide_suggested">Hide Suggestions in Feed</string>
 
     <!-- Miscellaneous options -->
     <string name="ig_dialog_misc_disable_story_autoswipe">Disable Story Auto-Swipe</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,6 +179,10 @@
     <string name="ig_dialog_dev_import">Import Dev Config</string>
     <string name="ig_dialog_dev_export">Export Dev Config</string>
     <string name="ig_dialog_dev_remove_build_expired">Remove Build Expired Popup</string>
+    <string name="ig_dialog_clear_cache">🔄 Clear Hooks Cache</string>
+    <string name="ig_dialog_section_clear_cache">Clear Hooks Cache</string>
+    <string name="ig_dialog_clear_cache_message">⚠️ This will force InstaEclipse to re-scan Instagram on next launch. The app will restart.</string>
+    <string name="ig_dialog_clear_cache_now">Clear Cache &amp; Restart</string>
     <string name="ig_dialog_unable_open_ui">Unable to open InstaEclipse UI.</string>
     <string name="ig_dialog_instagram_not_ready">Instagram is not open or ready.</string>
     <string name="ig_dialog_mc_overrides_not_found">mc_overrides.json not found.</string>

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "latest_version": "0.5.0",
+  "latest_version": "0.5.1",
   "update_url": "https://github.com/ReSo7200/InstaEclipse/releases/latest"
 }


### PR DESCRIPTION
# 🌘 InstaEclipse v0.5.1

> ✅ **No reinstall required.** You can update over your existing v0.5.0 installation.

---

## ✨ New Features

- **feat(feed):** Hide suggestions in feed + client-side reels blocker
- **feat(cache):** Clear Hooks Cache option added to main menu
- **feat(double-tap-like):** Disable double-tap to like on feed and reels

---

## 🐛 Bug Fixes

- **fix(ui):** Resolve lag and inbox long-press conflict
- **fix(android11):** Resolve `NoClassDefFoundError` on API 30
- **fix(module):** Remove dead `hookOwnModule` causing crash on launch
- **fix(ghost-indicator):** Replace emoji overlay with icon tint
- **fix(downloader):** Resolve "no media found" for feed posts on IG v426
- **fix(i18n):** make all toasts and feature labels fully translated 