### PR TITLE
Refactor Instagram TrackingLinkDisable

### DIFF
--- a/app/src/main/java/ps/reso/instaeclipse/mods/ads/TrackingLinkDisable.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/ads/TrackingLinkDisable.java
@@ -18,22 +18,27 @@ public class TrackingLinkDisable {
 
                         if (FeatureFlags.disableTrackingLinks) {
                             ClipData clipData = (ClipData) param.args[0];
-                            if (clipData == null || clipData.getItemCount() == 0 || clipData.getItemAt(0) == null || clipData.getItemAt(0).getText() == null) {
-                                return;
-                            }
-                            String x = clipData.getItemAt(0).getText().toString();
-                            if (x.contains("https://www.instagram.com/") && (x.contains("igsh=") || (x.contains("ig_rid=")))) { // Global
-                                param.args[0] = ClipData.newPlainText("URL", x.replaceAll("\\?.*", ""));
-                            } else if (x.contains("https://www.instagram.com/") && x.contains("?utm_source=")) { // Stories
-                                param.args[0] = ClipData.newPlainText("URL", x.replaceAll("\\?utm_source=.*", ""));
-                            }
-                            else if (x.contains("https://www.instagram.com/") && x.contains("?story_media_id=")){ // Highlights
-                                param.args[0] = ClipData.newPlainText("URL", x.replaceAll("\\?story_media_id=.*", ""));
-                            }
-                            // Saved-by rule: match saved-by or saved_by anywhere in query
-                            else if (x.contains("https://www.instagram.com/") &&
-                                    x.matches("(?i).*saved[-_]by.*")) {
-                                param.args[0] = ClipData.newPlainText("URL", x.replaceAll("\\?.*", ""));
+                            if (clipData == null || clipData.getItemCount() == 0) return;
+                            
+                            Item item = clipData.getItemAt(0);
+                            if (item == null || item.getText() == null) return;
+                            
+                            String url = item.getText().toString();
+                            
+                            // Only process Instagram links
+                            if (url.contains("https://www.instagram.com/")) {
+                                // Combined regex for: igsh, ig_rid, utm_source, story_media_id, or saved[-_]by
+                                boolean hasTracking = url.contains("igsh=") || 
+                                                      url.contains("ig_rid=") || 
+                                                      url.contains("utm_source=") || 
+                                                      url.contains("story_media_id=") || 
+                                                      url.matches("(?i).*saved[-_]by.*");
+                                
+                                if (hasTracking) {
+                                    // Strip everything from the first '?' onwards
+                                    String cleanUrl = url.replaceAll("\\?.*", "");
+                                    param.args[0] = ClipData.newPlainText("URL", cleanUrl);
+                                }
                             }
                         }
 

--- a/app/src/main/java/ps/reso/instaeclipse/mods/ads/TrackingLinkDisable.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/ads/TrackingLinkDisable.java
@@ -15,33 +15,29 @@ public class TrackingLinkDisable {
                 Class.forName("android.content.ClipData"), new XC_MethodHook() {
                     @Override
                     protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                        if (!FeatureFlags.disableTrackingLinks) return;
 
-                        if (FeatureFlags.disableTrackingLinks) {
-                            ClipData clipData = (ClipData) param.args[0];
-                            if (clipData == null || clipData.getItemCount() == 0) return;
-                            
-                            Item item = clipData.getItemAt(0);
-                            if (item == null || item.getText() == null) return;
-                            
-                            String url = item.getText().toString();
-                            
-                            // Only process Instagram links
-                            if (url.contains("https://www.instagram.com/")) {
-                                // Combined regex for: igsh, ig_rid, utm_source, story_media_id, or saved[-_]by
-                                boolean hasTracking = url.contains("igsh=") || 
-                                                      url.contains("ig_rid=") || 
-                                                      url.contains("utm_source=") || 
-                                                      url.contains("story_media_id=") || 
-                                                      url.matches("(?i).*saved[-_]by.*");
-                                
-                                if (hasTracking) {
-                                    // Strip everything from the first '?' onwards
-                                    String cleanUrl = url.replaceAll("\\?.*", "");
-                                    param.args[0] = ClipData.newPlainText("URL", cleanUrl);
-                                }
-                            }
+                        ClipData clipData = (ClipData) param.args[0];
+                        if (clipData == null || clipData.getItemCount() == 0) return;
+
+                        ClipData.Item item = clipData.getItemAt(0);
+                        if (item == null || item.getText() == null) return;
+
+                        String url = item.getText().toString();
+                        if (!url.contains("https://www.instagram.com/")) return;
+
+                        // Tracking params can appear anywhere in the query string, not just
+                        // as the first one — matching only "?param=" (old behavior) missed
+                        // links where another param came first, e.g. "?igshid=X&utm_source=...".
+                        boolean hasTracking = url.contains("igsh=")
+                                || url.contains("ig_rid=")
+                                || url.contains("utm_source=")
+                                || url.contains("story_media_id=")
+                                || url.matches("(?i).*saved[-_]by.*");
+
+                        if (hasTracking) {
+                            param.args[0] = ClipData.newPlainText("URL", url.replaceAll("\\?.*", ""));
                         }
-
                     }
                 });
     }


### PR DESCRIPTION
Improve readability and strip all Instagram URLs the same way - as all cases were already stripping everything from '?' onwards.