### PR TITLE
Version 0.6.0 hotfix

### DIFF
--- a/app/src/main/java/ps/reso/instaeclipse/mods/devops/DevOptionsUnlockHook.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/devops/DevOptionsUnlockHook.java
@@ -5,12 +5,15 @@ import org.luckypray.dexkit.query.FindClass;
 import org.luckypray.dexkit.query.FindMethod;
 import org.luckypray.dexkit.query.matchers.ClassMatcher;
 import org.luckypray.dexkit.query.matchers.MethodMatcher;
+import org.luckypray.dexkit.query.matchers.MethodsMatcher;
 import org.luckypray.dexkit.result.ClassData;
 import org.luckypray.dexkit.result.MethodData;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XposedBridge;
@@ -23,18 +26,34 @@ import ps.reso.instaeclipse.utils.log.ModuleLog;
 
 public class DevOptionsUnlockHook {
 
-    // MobileConfig param ID backing the "is employee" gate (LX/02il;->A00 in IG 429,
-    // renamed to LX/5sG;->A00 in IG 437+ after Meta re-generated the config schema).
-    // Both static (UserSession)Z accessors share this exact shape: null-check ->
-    // resolve UserSession to a MobileConfigUnsafeContext -> boolean getter with a
-    // hardcoded param ID. Try known IDs newest-first so current versions resolve fast.
+    private static final String MOBILECONFIG_GETTER_CLASS = "com.facebook.mobileconfig.factory.MobileConfigUnsafeContext";
+    private static final String USER_SESSION_CLASS = "com.instagram.common.session.UserSession";
+
+    // Structural-tier tuning. Confirmed against IG 436: among ~140 (UserSession)->boolean
+    // methods that read MobileConfig, the real "is employee" gate is the one minimal,
+    // branch-free pass-through (~9 opcodes) reused from 9 unrelated classes — every other
+    // candidate is either a bigger cached/branchy check (40+ opcodes) or has 1-2 callers.
+    private static final int MAX_GATE_OPCODES = 16;
+    private static final int MIN_CALLER_FAN_IN = 3;
+
+    // Legacy hardcoded MobileConfig IDs, kept only as a last-resort fallback below the
+    // structural tier. Meta regenerates this ID per build and NOT in version order (IG 436
+    // used a higher schema byte than IG 437), so this list is inherently a losing game —
+    // do not add to it; the structural tier (Tier 2) should make it unnecessary going forward.
     private static final long[] IS_EMPLOYEE_CONFIG_IDS = {
+            36310834636390667L, // IG 436 (LX/02mx;->A00, 0x8100830000010b)
             36310830341423371L, // IG 437+ (LX/5sG;->A00, 0x8100820000010b)
             36310856111227168L, // IG <= 429 (LX/02il;->A00, 0x81008800000120)
+            36310864701161762L, // older observed build
     };
 
     public void handleDevOptions(DexKitBridge bridge) {
         if (DexKitCache.isCacheValid()) {
+            Method cachedMethod = DexKitCache.loadMethod("DevOptionsMethod", Module.hostClassLoader);
+            if (cachedMethod != null) {
+                hookExactMethod(cachedMethod);
+                return;
+            }
             String cachedClass = DexKitCache.loadString("DevOptionsClass");
             if (cachedClass != null) {
                 hookBooleanMethodsViaReflection(cachedClass);
@@ -78,9 +97,30 @@ public class DevOptionsUnlockHook {
                 }
             }
 
-            // Tier 2: Failover to MobileConfig ID (The "Golden Anchor")
+            // Tier 2: Structural discovery — no string, no hardcoded ID. Finds the gate by
+            // its shape: a minimal, branch-free (UserSession)->boolean check that reads
+            // MobileConfig directly and is reused from many unrelated classes. Survives
+            // both string stripping and per-build MobileConfig ID churn.
             if (!found) {
-                ModuleLog.line("(InstaEclipse | DevOptionsEnable): ⚠️ Tier 1 failed. Discovery Tier 2 (Config ID)...");
+                ModuleLog.line("(InstaEclipse | DevOptionsEnable): ⚠️ Tier 1 failed. Discovery Tier 2 (Structural)...");
+                MethodData structural = resolveEmployeeGateStructurally(bridge);
+                if (structural != null) {
+                    try {
+                        Method targetMethod = structural.getMethodInstance(Module.hostClassLoader);
+                        DexKitCache.saveMethod("DevOptionsMethod", targetMethod);
+                        hookExactMethod(targetMethod);
+                        ModuleLog.line("(InstaEclipse | DevOptionsEnable): 🎯 Found via structural match: "
+                                + structural.getClassName() + "." + structural.getName());
+                        found = true;
+                    } catch (Throwable e) {
+                        ModuleLog.line("(InstaEclipse | DevOptionsEnable): ❌ Structural match failed to bind: " + e.getMessage());
+                    }
+                }
+            }
+
+            // Tier 3: Failover to hardcoded MobileConfig IDs (legacy, last resort)
+            if (!found) {
+                ModuleLog.line("(InstaEclipse | DevOptionsEnable): ⚠️ Tier 2 failed. Discovery Tier 3 (Config ID)...");
                 for (long configId : IS_EMPLOYEE_CONFIG_IDS) {
                     List<MethodData> idMethods = bridge.findMethod(FindMethod.create()
                             .matcher(MethodMatcher.create()
@@ -100,9 +140,9 @@ public class DevOptionsUnlockHook {
                 }
             }
 
-            // Final Debug Trace: If both fail, log where the string is used ANYWHERE
+            // Final Debug Trace: If all tiers fail, log where the string is used ANYWHERE
             if (!found) {
-                ModuleLog.line("(InstaEclipse | DevOptionsEnable): ❌ Tier 2 failed. Debugging global references...");
+                ModuleLog.line("(InstaEclipse | DevOptionsEnable): ❌ Tier 3 failed. Debugging global references...");
                 List<MethodData> debugMethods = bridge.findMethod(FindMethod.create()
                         .matcher(MethodMatcher.create().usingStrings("is_employee")));
                 for (MethodData m : debugMethods) {
@@ -112,6 +152,78 @@ public class DevOptionsUnlockHook {
 
         } catch (Exception e) {
             ModuleLog.line("(InstaEclipse | DevOptionsEnable): ❌ Error during discovery: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Resolves the "is employee" gate by shape instead of by name/ID:
+     * 1. Find MobileConfig's raw boolean-by-id getter — declaring class is
+     *    {@code MobileConfigUnsafeContext}, which keeps its real package name across
+     *    builds (shared Meta infra, not app-feature code), and it has exactly one
+     *    {@code (long)->boolean} overload, so this step is always unambiguous.
+     * 2. Collect every {@code (UserSession)->boolean} method that calls it directly —
+     *    there are ~140 of these on a typical build, one per MobileConfig-backed flag.
+     * 3. Discard anything bigger than a minimal pass-through (cached/branchy checks for
+     *    other flags are much larger), then rank survivors by how many distinct classes
+     *    call them. Ordinary single-feature checks have 1-2 callers; the shared employee
+     *    gate is reused everywhere.
+     */
+    private MethodData resolveEmployeeGateStructurally(DexKitBridge bridge) {
+        try {
+            List<MethodData> getters = bridge.findMethod(FindMethod.create()
+                    .matcher(MethodMatcher.create()
+                            .declaredClass(MOBILECONFIG_GETTER_CLASS)
+                            .returnType("boolean")
+                            .paramTypes("long")));
+            if (getters.isEmpty()) return null;
+
+            MethodsMatcher getterInvoke = MethodsMatcher.create();
+            for (MethodData getter : getters) {
+                getterInvoke.add(MethodMatcher.create(getter.getDescriptor()));
+            }
+
+            List<MethodData> candidates = bridge.findMethod(FindMethod.create()
+                    .matcher(MethodMatcher.create()
+                            .returnType("boolean")
+                            .paramTypes(USER_SESSION_CLASS)
+                            .invokeMethods(getterInvoke)));
+
+            MethodData best = null;
+            int bestFanIn = 0;
+            for (MethodData candidate : candidates) {
+                if (candidate.getOpCodes().size() > MAX_GATE_OPCODES) continue;
+
+                Set<String> callerClasses = new HashSet<>();
+                for (MethodData caller : candidate.getCallers()) {
+                    callerClasses.add(caller.getClassName());
+                }
+                if (callerClasses.size() > bestFanIn) {
+                    bestFanIn = callerClasses.size();
+                    best = candidate;
+                }
+            }
+            return bestFanIn >= MIN_CALLER_FAN_IN ? best : null;
+        } catch (Exception e) {
+            ModuleLog.line("(InstaEclipse | DevOptionsEnable): ❌ Structural discovery error: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private void hookExactMethod(Method m) {
+        try {
+            m.setAccessible(true);
+            XposedBridge.hookMethod(m, new XC_MethodHook() {
+                @Override
+                protected void beforeHookedMethod(MethodHookParam param) {
+                    if (FeatureFlags.isDevEnabled) {
+                        param.setResult(true);
+                        FeatureStatusTracker.setHooked("DevOptions");
+                    }
+                }
+            });
+            ModuleLog.line("(InstaEclipse | DevOptionsEnable): ✅ Hooked: " + m.getDeclaringClass().getName() + "." + m.getName());
+        } catch (Throwable e) {
+            ModuleLog.line("(InstaEclipse | DevOptionsEnable): ❌ Failed to hook resolved method: " + e.getMessage());
         }
     }
 

--- a/app/src/main/java/ps/reso/instaeclipse/mods/media/PostDownloadContextMenuHook.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/media/PostDownloadContextMenuHook.java
@@ -498,9 +498,17 @@ public class PostDownloadContextMenuHook {
 
         List<String> urls = FeedVideoDownloadHook.extractAllUrlsFromMedia(ctx, media);
 
-        // Carousel index: try the known field name first; fall back to scanning all int fields
-        // for one whose value fits [0, urlCount) — resilient to field renames across builds.
-        int carouselIdx = findCarouselIndex(clickHandler, urls.size());
+        // Carousel index: live view scan is primary (reads the actual visible slide, and
+        // now only trusts itself when exactly one on-screen carousel matches the target
+        // size — see ReelDownloadHook.findCarouselIndexFromView). Field-guessing on
+        // clickHandler is the fallback for when the scan is ambiguous or finds nothing;
+        // it's unreliable specifically for reels whose DOWNLOAD row was patched into the
+        // shared post-style option list (see ReelDownloadHook.installReduceOptionsListPatch),
+        // where clickHandler carries no real position field.
+        int viewIdx = urls.size() > 1
+                ? ReelDownloadHook.findCarouselIndexFromView(ctx, urls.size())
+                : -1;
+        final int carouselIdx = viewIdx >= 0 ? viewIdx : findCarouselIndex(clickHandler, urls.size());
 
         final String finalUser = username;
         final String finalId   = mediaId;

--- a/app/src/main/java/ps/reso/instaeclipse/mods/media/ReelDownloadHook.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/media/ReelDownloadHook.java
@@ -330,18 +330,24 @@ public class ReelDownloadHook {
     }
 
     /**
-     * Primary index resolver: walks the activity's live view hierarchy to find a
-     * ViewPager / ViewPager2 / ReboundViewPager whose adapter item count equals
-     * {@code carouselSize} and returns its current data index.
-     * Always accurate since it reads live view state, not the data-layer field.
+     * Primary index resolver: walks the activity's live view hierarchy for a
+     * ViewPager / ViewPager2 / ReboundViewPager / horizontal RecyclerView whose adapter
+     * item count equals {@code carouselSize} and returns its current data index.
+     * Multiple unrelated carousels can coincidentally share the same item count (e.g.
+     * two feed posts both showing 4 photos) — trusting the first DFS hit in that case
+     * previously misattributed the index to the wrong post. So every match is collected
+     * and the result is only trusted when exactly one candidate matches; otherwise the
+     * caller falls back to the data-layer field.
      *
-     * @return current position [0, carouselSize), or -1 if not found
+     * @return current position [0, carouselSize), or -1 if not found / ambiguous
      */
-    private static int findCarouselIndexFromView(Context ctx, int carouselSize) {
+    static int findCarouselIndexFromView(Context ctx, int carouselSize) {
         if (!(ctx instanceof Activity)) return -1;
         try {
             View root = ((Activity) ctx).getWindow().getDecorView();
-            return scanViewForCarousel(root, carouselSize);
+            List<Integer> matches = new java.util.ArrayList<>();
+            collectCarouselMatches(root, carouselSize, matches);
+            return matches.size() == 1 ? matches.get(0) : -1;
         } catch (Throwable ignored) {
             return -1;
         }
@@ -355,10 +361,11 @@ public class ReelDownloadHook {
     }
 
     /**
-     * Recursive DFS over the view tree. ViewPager / ViewPager2 / ReboundViewPager are
-     * AndroidX / Instagram common-UI classes — stable names, no obfuscation.
+     * Recursive DFS over the view tree, collecting the resolved index of every carousel
+     * whose adapter size matches — does not stop at the first hit. ViewPager / ViewPager2 /
+     * ReboundViewPager are AndroidX / Instagram common-UI classes — stable names, no obfuscation.
      */
-    private static int scanViewForCarousel(View view, int carouselSize) {
+    private static void collectCarouselMatches(View view, int carouselSize, List<Integer> out) {
         String cn = view.getClass().getName();
 
         // ViewPager / ViewPager2 / ReboundViewPager and any subclass
@@ -373,7 +380,7 @@ public class ReelDownloadHook {
                             "getCurrentWrappedDataIndex", "getCurrentRawDataIndex"}) {
                         try {
                             int cur = (int) view.getClass().getMethod(getter).invoke(view);
-                            if (cur >= 0) return cur;
+                            if (cur >= 0) { out.add(cur); break; }
                         } catch (NoSuchMethodException ignored) {}
                     }
                 }
@@ -392,16 +399,20 @@ public class ReelDownloadHook {
                             if (orientation != 0 /* HORIZONTAL */) lm = null;
                         } catch (Throwable ignored) {}
                         if (lm != null) {
+                            Integer pos = null;
                             try {
-                                int pos = (int) lm.getClass()
+                                int p = (int) lm.getClass()
                                         .getMethod("findFirstCompletelyVisibleItemPosition").invoke(lm);
-                                if (pos >= 0) return pos;
+                                if (p >= 0) pos = p;
                             } catch (Throwable ignored) {}
-                            try {
-                                int pos = (int) lm.getClass()
-                                        .getMethod("findFirstVisibleItemPosition").invoke(lm);
-                                if (pos >= 0) return pos;
-                            } catch (Throwable ignored) {}
+                            if (pos == null) {
+                                try {
+                                    int p = (int) lm.getClass()
+                                            .getMethod("findFirstVisibleItemPosition").invoke(lm);
+                                    if (p >= 0) pos = p;
+                                } catch (Throwable ignored) {}
+                            }
+                            if (pos != null) out.add(pos);
                         }
                     }
                 }
@@ -411,12 +422,9 @@ public class ReelDownloadHook {
         if (view instanceof ViewGroup) {
             ViewGroup vg = (ViewGroup) view;
             for (int i = 0; i < vg.getChildCount(); i++) {
-                int result = scanViewForCarousel(vg.getChildAt(i), carouselSize);
-                if (result >= 0) return result;
+                collectCarouselMatches(vg.getChildAt(i), carouselSize, out);
             }
         }
-
-        return -1;
     }
 
     private static void onOptionsBuilt(XC_MethodHook.MethodHookParam param) {


### PR DESCRIPTION
# 🌘 InstaEclipse v0.6.0 - Hotfix

> ✅ **No reinstall required.** You can update over your existing v0.5.x installation.

> [!IMPORTANT]
> **InstaEclipse is being succeeded by the [Purrfect](https://t.me/purrfect_tg) project.** Development here will stay active until Purrfect reaches a stable release — follow the Telegram channel for progress updates.

---

🐛 Bug Fixes

- fix(devops): Enable Developer Mode — replaced the fragile hardcoded MobileConfig-ID lookup with a structural discovery pass that finds Instagram's employee-gate check by its shape (a minimal, branch-free MobileConfig read reused across many unrelated classes) instead of a version-specific numeric ID, so the toggle keeps working across future Instagram updates without manual patching
- fix(media): Downloading a multi-image reel always saved slide 1 regardless of which slide was showing. The current slide is now read directly from Instagram's live view state instead of guessed from a data field, with the old field-based guess kept only as a fallback for ambiguous cases
