### PR TITLE
Fix Download option missing on your own stories

### DIFF
--- a/app/src/main/java/ps/reso/instaeclipse/mods/media/FeedVideoDownloadHook.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/media/FeedVideoDownloadHook.java
@@ -107,6 +107,11 @@ public class FeedVideoDownloadHook {
     private static Method   dictUserGetter;    // () -> UserClass on MutableMediaDictIntf
     // userUsernameGetter lives in UserUtils — resolved here and stored there
 
+    // Pando field ids are the Java String hash of the field name, so these stay valid
+    // across Instagram builds: "username".hashCode() / "full_name".hashCode().
+    private static final int USERNAME_FIELD_HASH  = -265713450;
+    private static final int FULL_NAME_FIELD_HASH = -1677176261;
+
     // ── Uri.parse fallback buffer ─────────────────────────────────────────────
     private static final class UrlEntry {
         final String url; final long time;
@@ -931,16 +936,18 @@ public class FeedVideoDownloadHook {
      * from the LiveTreeMediaDict without guessing obfuscated method names.
      */
     private static void resolveUsernameGetter(DexKitBridge bridge, ClassLoader classLoader) {
-        // Cache hit: restore userClass and userUsernameGetter without DexKit
+        // Cache hit: restore userClass and userUsernameGetter without DexKit. Both must be
+        // present — with the getter missing, UserUtils falls back to scanning User for any
+        // lowercase String, which is how the display name got picked in the first place.
+        // Key bumped to _v2: an existing cache would otherwise restore the display-name
+        // getter this method used to resolve.
         if (DexKitCache.isCacheValid()) {
             String cachedClassName = DexKitCache.loadString("UserClass");
-            Method cachedGetter    = DexKitCache.loadMethod("UsernameGetter", classLoader);
-            if (cachedClassName != null) {
+            Method cachedGetter    = DexKitCache.loadMethod("UsernameGetter_v2", classLoader);
+            if (cachedClassName != null && cachedGetter != null) {
                 try {
                     userClass = classLoader.loadClass(cachedClassName);
-                    if (cachedGetter != null) {
-                        UserUtils.userUsernameGetter = cachedGetter;
-                    }
+                    UserUtils.userUsernameGetter = cachedGetter;
                     resolveDictUserGetter(bridge, classLoader);
                     return;
                 } catch (Throwable ignored) {}
@@ -962,21 +969,38 @@ public class FeedVideoDownloadHook {
             DexKitCache.saveString("UserClass", userClass.getName());
             ModuleLog.line("(IE|DL|Username) userClass=" + userClass.getName());
 
-            // Resolve the username getter on User via the stable GraphQL field ID -265713450.
+            // Resolve the username getter on User via the "username" Pando field id.
+            //
+            // That id alone is not enough: User also has a display-name getter that
+            // reads username and falls back to full_name, so two methods match and
+            // get(0) returned the display-name one. Nothing downstream can tell them
+            // apart afterwards — UserUtils.isValidUsername() accepts any lowercase
+            // string, so an all-lowercase display name passes as a handle and every
+            // download lands in a folder named after it. Drop the candidates that also
+            // read full_name; the one left is the plain username getter.
             try {
-                List<MethodData> ugMethods = bridge.findMethod(FindMethod.create()
-                        .matcher(MethodMatcher.create()
-                                .declaredClass("com.instagram.user.model.User")
-                                .returnType("java.lang.String")
-                                .paramCount(0)
-                                .usingNumbers(-265713450)));
+                List<MethodData> ugMethods = findUserFieldGetters(bridge, USERNAME_FIELD_HASH);
+
+                if (ugMethods.size() > 1) {
+                    Set<String> readsFullName = new HashSet<>();
+                    for (MethodData md : findUserFieldGetters(bridge, FULL_NAME_FIELD_HASH)) {
+                        readsFullName.add(md.getDescriptor());
+                    }
+                    List<MethodData> pure = new ArrayList<>();
+                    for (MethodData md : ugMethods) {
+                        if (!readsFullName.contains(md.getDescriptor())) pure.add(md);
+                    }
+                    // Only narrow when it leaves something — never down to nothing.
+                    if (!pure.isEmpty()) ugMethods = pure;
+                }
+
                 if (!ugMethods.isEmpty()) {
                     UserUtils.userUsernameGetter = ugMethods.get(0).getMethodInstance(classLoader);
                     UserUtils.userUsernameGetter.setAccessible(true);
-                    DexKitCache.saveMethod("UsernameGetter", UserUtils.userUsernameGetter);
+                    DexKitCache.saveMethod("UsernameGetter_v2", UserUtils.userUsernameGetter);
                     ModuleLog.line("(IE|DL|Username) userUsernameGetter=" + UserUtils.userUsernameGetter.getName());
                 } else {
-                    ModuleLog.line("(IE|DL|Username) ❌ userUsernameGetter not found via -265713450");
+                    ModuleLog.line("(IE|DL|Username) ❌ userUsernameGetter not found");
                 }
             } catch (Throwable t) {
                 ModuleLog.line("(IE|DL|Username) ❌ userUsernameGetter resolution: " + t);
@@ -987,6 +1011,16 @@ public class FeedVideoDownloadHook {
         } catch (Throwable t) {
             ModuleLog.line("(IE|DL|Username) ❌ resolveUsernameGetter: " + t);
         }
+    }
+
+    /** Zero-arg String getters on User that read the Pando field with the given id. */
+    private static List<MethodData> findUserFieldGetters(DexKitBridge bridge, int fieldHash) {
+        return bridge.findMethod(FindMethod.create()
+                .matcher(MethodMatcher.create()
+                        .declaredClass("com.instagram.user.model.User")
+                        .returnType("java.lang.String")
+                        .paramCount(0)
+                        .usingNumbers(fieldHash)));
     }
 
     private static void resolveDictUserGetter(DexKitBridge bridge, ClassLoader classLoader) {

--- a/app/src/main/java/ps/reso/instaeclipse/mods/media/StoryDownloadHook.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/media/StoryDownloadHook.java
@@ -57,156 +57,212 @@ public class StoryDownloadHook {
 
     // ── Hook 1: inject "Download" into the story options button list ──────────
     //
-    // Found via "[INTERNAL] Pause Playback" string + CharSequence[] return type, 1 param.
+    // Found via "[INTERNAL] Pause Playback" string + CharSequence[] return type.
     // afterHookedMethod: appends our "Download" entry to the returned CharSequence[] array.
+    //
+    // Instagram builds the option list for YOUR OWN story with a different method than
+    // the one used for other users' stories, so every CharSequence[] candidate behind the
+    // anchor string is hooked rather than just the first.
 
     private void installButtonInjectorHook(DexKitBridge bridge, ClassLoader classLoader) {
-        Method method = DexKitCache.isCacheValid()
-                ? DexKitCache.loadMethod("StoryDownload_button", classLoader) : null;
+        XC_MethodHook injector = new XC_MethodHook() {
+            @Override
+            protected void afterHookedMethod(MethodHookParam param) {
+                if (!FeatureFlags.enableStoryDownload) return;
+                CharSequence[] original = (CharSequence[]) param.getResult();
+                if (original == null) return;
 
-        if (method == null) {
-            try {
-                List<MethodData> methods = bridge.findMethod(FindMethod.create()
-                        .matcher(MethodMatcher.create()
-                                .usingStrings("[INTERNAL] Pause Playback")
-                                .paramCount(1)));
-
-                if (methods.isEmpty()) {
-                    ModuleLog.line("(IE|Story) ❌ Button builder method not found");
-                    return;
+                // Guard: don't inject twice
+                String dlLabel = I18n.t(AndroidAppHelper.currentApplication(), R.string.ig_dl_title);
+                for (CharSequence cs : original) {
+                    if (dlLabel.contentEquals(cs)) return;
                 }
 
-                for (MethodData md : methods) {
-                    try {
-                        Method m = md.getMethodInstance(classLoader);
-                        if (m.getReturnType().isArray() &&
-                                CharSequence.class.isAssignableFrom(m.getReturnType().getComponentType())) {
-                            method = m;
-                            break;
-                        }
-                    } catch (Throwable ignored) {}
-                }
-            } catch (Throwable t) {
-                ModuleLog.line("(IE|Story) ❌ Button builder DexKit: " + t);
+                CharSequence[] extended = new CharSequence[original.length + 1];
+                System.arraycopy(original, 0, extended, 0, original.length);
+                extended[original.length] = dlLabel;
+                param.setResult(extended);
+            }
+        };
+
+        // Cache hit: restore all previously-found builder methods
+        if (DexKitCache.isCacheValid()) {
+            List<Method> cached = DexKitCache.loadMethods("StoryDownload_button", classLoader);
+            if (cached != null && !cached.isEmpty()) {
+                for (Method m : cached) XposedBridge.hookMethod(m, injector);
                 return;
             }
         }
 
-        if (method == null) {
-            ModuleLog.line("(IE|Story) ❌ No CharSequence[] return type candidate found");
-            return;
-        }
-        DexKitCache.saveMethod("StoryDownload_button", method);
-
         try {
-            XposedBridge.hookMethod(method, new XC_MethodHook() {
-                @Override
-                protected void afterHookedMethod(MethodHookParam param) {
-                    if (!FeatureFlags.enableStoryDownload) return;
-                    CharSequence[] original = (CharSequence[]) param.getResult();
-                    if (original == null) return;
+            // No paramCount filter — the self-story builder takes 3 args, the others'-story
+            // one takes 1. The CharSequence[] return type below is the real gate.
+            List<MethodData> methods = bridge.findMethod(FindMethod.create()
+                    .matcher(MethodMatcher.create()
+                            .usingStrings("[INTERNAL] Pause Playback")));
 
-                    // Guard: don't inject twice
-                    String dlLabel = I18n.t(AndroidAppHelper.currentApplication(), R.string.ig_dl_title);
-                    for (CharSequence cs : original) {
-                        if (dlLabel.contentEquals(cs)) return;
-                    }
+            if (methods.isEmpty()) {
+                ModuleLog.line("(IE|Story) ❌ Button builder method not found");
+                return;
+            }
 
-                    CharSequence[] extended = new CharSequence[original.length + 1];
-                    System.arraycopy(original, 0, extended, 0, original.length);
-                    extended[original.length] = dlLabel;
-                    param.setResult(extended);
-                }
-            });
+            List<Method> hooked = new ArrayList<>();
+            for (MethodData md : methods) {
+                try {
+                    Method m = md.getMethodInstance(classLoader);
+                    Class<?> ret = m.getReturnType();
+                    if (!ret.isArray() || !CharSequence.class.isAssignableFrom(ret.getComponentType())) continue;
+                    m.setAccessible(true);
+                    XposedBridge.hookMethod(m, injector);
+                    hooked.add(m);
+                } catch (Throwable ignored) {}
+            }
+
+            if (hooked.isEmpty()) {
+                ModuleLog.line("(IE|Story) ❌ No CharSequence[] return type candidate found");
+                return;
+            }
+            DexKitCache.saveMethods("StoryDownload_button", hooked);
 
         } catch (Throwable t) {
-            ModuleLog.line("(IE|Story) ❌ Button builder hook: " + t);
+            ModuleLog.line("(IE|Story) ❌ Button builder DexKit: " + t);
         }
     }
 
     // ── Hook 2: handle click on our "Download" option ────────────────────────
     //
-    // Found via "explore_viewer" + "friendships/mute_friend_reel/%s/" strings.
+    // Found via the "[INTERNAL] Pause Playback" story-options anchor + void return.
     // beforeHookedMethod: reads the CharSequence param (the tapped label); if it
-    // equals "Download", triggers the download. Context and ReelItem are resolved
-    // from fields on 'this' or same-class params.
+    // equals "Download", triggers the download. The ReelItem and the Context are
+    // resolved by reflection over 'this' and the arguments, and are not always on
+    // the same object.
+    //
+    // The matcher deliberately does not also require "explore_viewer" and
+    // "friendships/mute_friend_reel/%s/": Explore-viewer and Mute only exist on someone
+    // else's story, so anchoring on them could never match the self-story dispatcher.
 
     private void installClickHandlerHook(DexKitBridge bridge, ClassLoader classLoader) {
-        Method method = DexKitCache.isCacheValid()
-                ? DexKitCache.loadMethod("StoryDownload_click", classLoader) : null;
+        XC_MethodHook clickHook = new XC_MethodHook() {
+            @Override
+            protected void beforeHookedMethod(MethodHookParam param) {
+                if (!FeatureFlags.enableStoryDownload) return;
 
-        if (method == null) {
-            try {
-                List<MethodData> methods = bridge.findMethod(FindMethod.create()
-                        .matcher(MethodMatcher.create()
-                                .returnType("void")
-                                .usingStrings("explore_viewer",
-                                        "friendships/mute_friend_reel/%s/",
-                                        "[INTERNAL] Pause Playback")));
+                // 1. Find which button was tapped
+                CharSequence tapped = null;
+                for (Object arg : param.args) {
+                    if (arg instanceof CharSequence cs) { tapped = cs; break; }
+                }
+                String dlLabel = I18n.t(AndroidAppHelper.currentApplication(), R.string.ig_dl_title);
+                if (tapped == null || !dlLabel.contentEquals(tapped)) return;
 
-                if (methods.isEmpty()) {
-                    ModuleLog.line("(IE|Story) ❌ Click handler not found");
+                // 2. Consume the event — Instagram won't process an option it didn't add
+                param.setResult(null);
+
+                // 3. Locate the object that holds ReelItem — it is either 'this' or a
+                //    parameter of the same declaring class (piko's smali shows the latter).
+                Object holder = findReelItemHolder(param);
+                ModuleLog.line("(IE|Story) holder=" + (holder != null ? holder.getClass().getName() : "null"));
+                Object mediaHolder = holder != null ? holder : param.thisObject;
+
+                // 4. Extract the Context. On the own-story menu the argument holding the
+                //    ReelItem carries no Context, so fall back to the other arguments
+                //    rather than giving up on the holder alone.
+                Context ctx = findContext(mediaHolder);
+                if (ctx == null) ctx = findContext(param.thisObject);
+                for (int i = 0; ctx == null && i < param.args.length; i++) {
+                    ctx = findContext(param.args[i]);
+                }
+                if (ctx == null) {
+                    ModuleLog.line("(IE|Story) ❌ Context not found");
                     return;
                 }
-                method = methods.get(0).getMethodInstance(classLoader);
-                DexKitCache.saveMethod("StoryDownload_click", method);
-            } catch (Throwable t) {
-                ModuleLog.line("(IE|Story) ❌ Click handler DexKit: " + t);
+
+                // 5. Extract story URL via ReelItem → media object field graph
+                String url = extractStoryUrl(mediaHolder);
+                ModuleLog.line("(IE|Story) url=" + url);
+
+                if (url == null || url.isEmpty()) {
+                    Toast.makeText(ctx, I18n.t(ctx, R.string.ig_toast_story_url_not_found), Toast.LENGTH_SHORT).show();
+                    return;
+                }
+
+                currentStoryUsername = extractUsernameFromReelItemHolder(mediaHolder);
+                currentStoryMediaId  = extractMediaIdFromReelItemHolder(mediaHolder);
+                startDownload(ctx, url, isVideoUrl(url));
+            }
+        };
+
+        // Cache hit: restore all previously-found click handler methods
+        if (DexKitCache.isCacheValid()) {
+            List<Method> cached = DexKitCache.loadMethods("StoryDownload_click", classLoader);
+            if (cached != null && !cached.isEmpty()) {
+                for (Method m : cached) XposedBridge.hookMethod(m, clickHook);
+                FeatureStatusTracker.setHooked("StoryDownload");
                 return;
             }
         }
 
         try {
-            XposedBridge.hookMethod(method, new XC_MethodHook() {
+            List<MethodData> results = bridge.findMethod(FindMethod.create()
+                    .matcher(MethodMatcher.create()
+                            .returnType("void")
+                            .usingStrings("[INTERNAL] Pause Playback")));
 
-                @Override
-                protected void beforeHookedMethod(MethodHookParam param) {
-                    if (!FeatureFlags.enableStoryDownload) return;
+            if (results.isEmpty()) {
+                ModuleLog.line("(IE|Story) ❌ Click handler not found");
+                return;
+            }
 
-                    // 1. Find which button was tapped
-                    CharSequence tapped = null;
-                    for (Object arg : param.args) {
-                        if (arg instanceof CharSequence cs) { tapped = cs; break; }
-                    }
-                    String dlLabel = I18n.t(AndroidAppHelper.currentApplication(), R.string.ig_dl_title);
-                    if (tapped == null || !dlLabel.contentEquals(tapped)) return;
+            // Static methods are deliberately NOT excluded here (unlike the post overflow
+            // menu, where the dispatcher is an instance method): the story dispatchers are
+            // static helpers that take the outer class as a parameter, which is the case
+            // findReelItemHolder() already accounts for.
+            List<Method> candidates = new ArrayList<>();
+            for (MethodData md : results) {
+                try {
+                    candidates.add(md.getMethodInstance(classLoader));
+                } catch (Throwable ignored) {}
+            }
 
-                    // 2. Consume the event — Instagram won't process an option it didn't add
-                    param.setResult(null);
+            // The dispatcher receives the tapped label, so anything without a CharSequence
+            // parameter is option-list plumbing that merely mentions the same anchor string.
+            // Applied only when it leaves something behind, so a build that breaks the
+            // assumption degrades to "hook everything" rather than "hook nothing".
+            boolean anyCharSeq = false;
+            for (Method m : candidates) {
+                if (hasCharSequenceParam(m)) { anyCharSeq = true; break; }
+            }
 
-                    // 3. Locate the object that holds ReelItem — it is either 'this' or a
-                    //    parameter of the same declaring class (piko's smali shows the latter).
-                    Object holder = findReelItemHolder(param);
-                    ModuleLog.line("(IE|Story) holder=" + (holder != null ? holder.getClass().getName() : "null"));
-
-                    // 4. Extract the Context
-                    Context ctx = findContext(holder != null ? holder : param.thisObject);
-                    if (ctx == null) {
-                        ModuleLog.line("(IE|Story) ❌ Context not found");
-                        return;
-                    }
-
-                    // 5. Extract story URL via ReelItem → media object field graph
-                    String url = extractStoryUrl(holder != null ? holder : param.thisObject);
-                    ModuleLog.line("(IE|Story) url=" + url);
-
-                    if (url == null || url.isEmpty()) {
-                        Toast.makeText(ctx, I18n.t(ctx, R.string.ig_toast_story_url_not_found), Toast.LENGTH_SHORT).show();
-                        return;
-                    }
-
-                    Object effectiveHolder = holder != null ? holder : param.thisObject;
-                    currentStoryUsername = extractUsernameFromReelItemHolder(effectiveHolder);
-                    currentStoryMediaId  = extractMediaIdFromReelItemHolder(effectiveHolder);
-                    startDownload(ctx, url, isVideoUrl(url));
+            List<Method> hooked = new ArrayList<>();
+            for (Method m : candidates) {
+                if (anyCharSeq && !hasCharSequenceParam(m)) continue;
+                try {
+                    m.setAccessible(true);
+                    XposedBridge.hookMethod(m, clickHook);
+                    hooked.add(m);
+                } catch (Throwable t) {
+                    ModuleLog.line("(IE|Story) ❌ Failed to hook click candidate: " + t);
                 }
-            });
+            }
 
+            if (hooked.isEmpty()) {
+                ModuleLog.line("(IE|Story) ❌ No click handler methods could be hooked");
+                return;
+            }
+            DexKitCache.saveMethods("StoryDownload_click", hooked);
             FeatureStatusTracker.setHooked("StoryDownload");
 
         } catch (Throwable t) {
             ModuleLog.line("(IE|Story) ❌ Click handler hook: " + t);
         }
+    }
+
+    /** True when the method takes a CharSequence (the tapped option label). */
+    private static boolean hasCharSequenceParam(Method m) {
+        for (Class<?> p : m.getParameterTypes()) {
+            if (CharSequence.class.isAssignableFrom(p)) return true;
+        }
+        return false;
     }
 
     // ── URL extraction ────────────────────────────────────────────────────────


### PR DESCRIPTION
Downloading your own story wasn't possible — the module's **Download** row never appeared there, so the only option was Instagram's native **Save**, which drops the music track from stories that have one. InstaEclipse's downloader grabs the rendered `video_version`, so the music is preserved.

Tested on Instagram **439.0.0.37.89** (Pixel 8 Pro, Android 16), own + other users' stories, video and photo.

Two independent fixes, one commit each — happy to split into separate PRs if you'd prefer.

---

### 1. `fix(story)` — own-story menu — `StoryDownloadHook.java`

Instagram builds the self-story option list with a different method than the others'-story one, and dispatches its taps through a different handler:

| Menu | Builder | Options |
|---|---|---|
| Your own story | 3 args | `Delete, Archive, Save video, Highlight, Edit AI label, Share, …` |
| Someone else's | 1 arg | `Report, Mute, AI info` |

The button injector filtered on `paramCount(1)` and stopped at the first `CharSequence[]` candidate, so it only ever found the others'-story builder. The click matcher required `"explore_viewer"` and `"friendships/mute_friend_reel/%s/"` — Explore-viewer and Mute only exist on someone else's story, so it could never match the self-story dispatcher.

Now every `CharSequence[]` candidate behind the `"[INTERNAL] Pause Playback"` anchor is hooked, and every `void` handler that receives the tapped label. Static methods are deliberately kept as candidates: unlike the post overflow menu, the story dispatchers are static helpers taking the outer class as a parameter.

Resolving the media needed a change too — the self-story dispatcher passes the ReelItem and the Context on **separate** arguments, so the Context is now looked up across `this` and every argument rather than on the ReelItem holder alone.

No new toggle; folded into the existing `enableStoryDownload`. Others'-story behaviour is unchanged.

### 2. `fix(download)` — wrong username getter — `FeedVideoDownloadHook.java`

Found while testing the above, but **not story-specific — it affects every download type**.

`"username".hashCode()` (`-265713450`) matches *two* zero-arg `String` getters on `com.instagram.user.model.User`: the username, and a display-name getter that reads username and falls back to `full_name`. `get(0)` picked the latter.

Nothing downstream caught it: `UserUtils.isValidUsername()` accepts any lowercase string, so an all-lowercase display name passes as a handle. On my account (`izadiegizabal`, display name `izadi`) every download — posts, reels, stories, profile pictures — was filed under `izadi`. Accounts whose display name has capitals or spaces failed the regex and fell through to the fallback scan, which is why this went unnoticed.

The fix drops candidates that also read `full_name`, leaving the plain username getter. Both field ids are named constants now, with a note that they're just `String.hashCode()` of the Pando field name and so stay valid across builds. Cache key bumped to `_v2` since an existing cache would restore the display-name getter.

---

### Notes

- `StoryMentionHook.java` uses the same two anchors with the same take-the-first shape, so **View Mentions** is likely missing on own stories for the same reason. Left out to keep this diff reviewable.
- No changes to `FeatureFlags`, `SettingsManager`, `FeatureManager`, `FeaturesFragment`, `strings.xml`, `Module.java`, `version.json`, or the README.