### PR TITLE
fix(media): correct video downloads and add Story format selection

### DIFF
--- a/app/src/main/java/ps/reso/instaeclipse/mods/media/DownloadSaveService.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/media/DownloadSaveService.java
@@ -22,6 +22,7 @@ import android.widget.Toast;
 import androidx.documentfile.provider.DocumentFile;
 
 import ps.reso.instaeclipse.R;
+import ps.reso.instaeclipse.utils.log.ModuleLog;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -61,6 +62,18 @@ public class DownloadSaveService extends Service {
     private long lastNotifMs  = 0;
     private int  lastNotifPct = -1;
 
+    private static final class SavedMedia {
+        final Uri uri;
+        final String filename;
+        final String mimeType;
+
+        SavedMedia(Uri uri, String filename, String mimeType) {
+            this.uri = uri;
+            this.filename = filename;
+            this.mimeType = mimeType;
+        }
+    }
+
     @Override
     public void onCreate() {
         super.onCreate();
@@ -99,11 +112,11 @@ public class DownloadSaveService extends Service {
 
         new Thread(() -> {
             try {
-                Uri savedUri = fAudio != null
+                SavedMedia saved = fAudio != null
                         ? downloadMergeAndSave(fUrl, fAudio, fFile, fMime, fSave, fUser, fUF)
                         : downloadAndSave(fUrl, fFile, fMime, fSave, fUser, fUF);
-                postDoneNotification(sid, "Saved: " + fFile, fMime, savedUri);
-                showToast(getString(R.string.ig_toast_file_saved, fFile));
+                postDoneNotification(sid, "Saved: " + saved.filename, saved.mimeType, saved.uri);
+                showToast(getString(R.string.ig_toast_file_saved, saved.filename));
             } catch (Throwable e) {
                 postDoneNotification(sid, "Download failed: " + e.getMessage(), null, null);
                 showToast(getString(R.string.ig_toast_download_failed, e.getMessage()));
@@ -117,14 +130,13 @@ public class DownloadSaveService extends Service {
 
     // ── Download helpers ──────────────────────────────────────────────────────
 
-    private Uri downloadAndSave(String url, String filename, String mimeType,
-                                String saveUri, String username, boolean usernameFolder)
+    private SavedMedia downloadAndSave(String url, String filename, String mimeType,
+                                       String saveUri, String username, boolean usernameFolder)
             throws Exception {
-        File tmp = File.createTempFile("ie_dl_", mimeType.contains("video") ? ".mp4" : ".jpg",
-                getCacheDir());
+        File tmp = File.createTempFile("ie_dl_", ".bin", getCacheDir());
         try {
             pushProgress("Downloading…", 0, 100, false);
-            downloadToFile(url, tmp, (done, total) -> {
+            String responseType = downloadToFile(url, tmp, (done, total) -> {
                 if (total > 0) {
                     int pct = (int) (done * 95 / total);
                     maybeUpdateProgress("Downloading…", pct, 100);
@@ -132,17 +144,23 @@ public class DownloadSaveService extends Service {
                     maybeUpdateProgress("Downloading…", 0, 0, true);
                 }
             });
+            MediaTypeDetector.Result detected = MediaTypeDetector.resolve(
+                    tmp, responseType, mimeType, filename);
+            ModuleLog.line("(IE|DL|Type) requested=" + mimeType + " response=" + responseType
+                    + " detected=" + detected.kind + " file=" + detected.filename);
             pushProgress("Saving…", 97, 100, false);
-            return writeViaSaf(tmp, filename, mimeType, saveUri, username, usernameFolder);
+            Uri uri = writeViaSaf(tmp, detected.filename, detected.mimeType,
+                    saveUri, username, usernameFolder);
+            return new SavedMedia(uri, detected.filename, detected.mimeType);
         } finally {
             //noinspection ResultOfMethodCallIgnored
             tmp.delete();
         }
     }
 
-    private Uri downloadMergeAndSave(String videoUrl, String audioUrl, String filename,
-                                     String mimeType, String saveUri,
-                                     String username, boolean usernameFolder)
+    private SavedMedia downloadMergeAndSave(String videoUrl, String audioUrl, String filename,
+                                            String mimeType, String saveUri,
+                                            String username, boolean usernameFolder)
             throws Exception {
         File cacheDir = getCacheDir();
         long ts = System.currentTimeMillis();
@@ -173,7 +191,11 @@ public class DownloadSaveService extends Service {
             mergeVideoAudio(tv.getAbsolutePath(), ta.getAbsolutePath(), out.getAbsolutePath());
 
             pushProgress("Saving…", 97, 100, false);
-            return writeViaSaf(out, filename, mimeType, saveUri, username, usernameFolder);
+            String corrected = MediaTypeDetector.withCorrectExtension(
+                    filename, MediaTypeDetector.Kind.VIDEO);
+            Uri uri = writeViaSaf(out, corrected, "video/mp4",
+                    saveUri, username, usernameFolder);
+            return new SavedMedia(uri, corrected, "video/mp4");
         } finally {
             //noinspection ResultOfMethodCallIgnored
             tv.delete();
@@ -221,11 +243,12 @@ public class DownloadSaveService extends Service {
         void onProgress(long bytesRead, long totalBytes);
     }
 
-    private static void downloadToFile(String url, File dest, ProgressCallback cb)
+    private static String downloadToFile(String url, File dest, ProgressCallback cb)
             throws Exception {
         HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
         conn.setRequestProperty("User-Agent", UA);
         conn.connect();
+        String contentType = conn.getContentType();
         long total = conn.getContentLengthLong(); // -1 if server doesn't send Content-Length
         try (InputStream in = conn.getInputStream();
              FileOutputStream fos = new FileOutputStream(dest)) {
@@ -240,6 +263,7 @@ public class DownloadSaveService extends Service {
         } finally {
             conn.disconnect();
         }
+        return contentType;
     }
 
     private static void mergeVideoAudio(String vp, String ap, String op) throws Exception {

--- a/app/src/main/java/ps/reso/instaeclipse/mods/media/FeedVideoDownloadHook.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/media/FeedVideoDownloadHook.java
@@ -66,6 +66,7 @@ import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ExecutorService;
@@ -93,6 +94,10 @@ public class FeedVideoDownloadHook {
     private static Class<?> mediaExtKtClass;
     private static Class<?> mediaClass;
     static Class<?> mutableMediaDictIntfClass;
+    private static Class<?> liveTreeMediaDictClass;
+    private static MediaModelResolver.Result mediaModel;
+    private static final List<Method> resolvedVideoVersionsGetters = new ArrayList<>();
+    private static Method resolvedIsVideoMethod;
     private static Method   methodImageUrl;         // MediaExtKt: static (Context, Media) -> String
 
     // VideoVersionIntf – stable public interface with getUrl()
@@ -150,41 +155,18 @@ public class FeedVideoDownloadHook {
             videoVersionGetUrl = videoVersionIntfClass.getMethod("getUrl");
         } catch (Throwable ignored) {}
 
-        // Load MutableMediaDictIntf and collect () -> List methods from it
-        // AND its direct superinterfaces only (Instagram 423+ moved Cz7() to LX/IdM).
-        // Do NOT recurse deeper — LX/IdM's own ancestors flood us with unrelated methods.
-        try {
-            mutableMediaDictIntfClass = classLoader.loadClass("com.instagram.feed.media.MutableMediaDictIntf");
-            Set<String> seen = new HashSet<>();
-            // Declared methods on MutableMediaDictIntf itself (DIS, BJ4, CjW, ...)
-            for (Method m : mutableMediaDictIntfClass.getDeclaredMethods()) {
-                if (m.getParameterCount() == 0 && List.class.isAssignableFrom(m.getReturnType())) {
-                    if (seen.add(m.getName())) { m.setAccessible(true); carouselCandidates.add(m); }
-                }
-            }
-            // Direct superinterfaces only (captures Cz7() from LX/IdM without going deeper)
-            for (Class<?> superIface : mutableMediaDictIntfClass.getInterfaces()) {
-                String sn = superIface.getName();
-                if (!sn.startsWith("com.instagram.") && !sn.startsWith("com.facebook.") && !sn.startsWith("X.")) continue;
-                for (Method m : superIface.getDeclaredMethods()) {
-                    if (m.getParameterCount() == 0 && List.class.isAssignableFrom(m.getReturnType())) {
-                        if (seen.add(m.getName())) { m.setAccessible(true); carouselCandidates.add(m); }
-                    }
-                }
-            }
-            // Instagram 437+ moved nearly all Pando field accessors off the interface and onto
-            // the concrete backing class (com.instagram.feed.media.LiveTreeMediaDict, which
-            // implements MutableMediaDictIntf) — the interface itself now declares almost
-            // nothing. Scan the concrete class too so carouselCandidates isn't left empty.
-            try {
-                Class<?> liveTreeDictClass = classLoader.loadClass("com.instagram.feed.media.LiveTreeMediaDict");
-                for (Method m : liveTreeDictClass.getDeclaredMethods()) {
-                    if (m.getParameterCount() == 0 && List.class.isAssignableFrom(m.getReturnType())) {
-                        if (seen.add(m.getName())) { m.setAccessible(true); carouselCandidates.add(m); }
-                    }
-                }
-            } catch (Throwable ignored) {}
-        } catch (Throwable ignored) {}
+        // Resolve the old interface and modern concrete model independently. In recent
+        // Instagram builds MutableMediaDictIntf may be absent; nesting the LiveTree lookup
+        // under it made Reel downloads fall through to the JPG cover (issue #204).
+        mediaModel = MediaModelResolver.resolve(classLoader);
+        mutableMediaDictIntfClass = mediaModel.mutableDictClass;
+        liveTreeMediaDictClass = mediaModel.liveTreeDictClass;
+        carouselCandidates.clear();
+        carouselCandidates.addAll(mediaModel.listCandidates);
+        ModuleLog.line("(IE|DL) media model: mutable="
+                + (mutableMediaDictIntfClass != null) + " liveTree="
+                + (liveTreeMediaDictClass != null) + " listCandidates="
+                + carouselCandidates.size());
 
         installUriCaptureHook();
     }
@@ -430,10 +412,12 @@ public class FeedVideoDownloadHook {
                     ModuleLog.line("(IE|DL) stepA1 videoUrl=" + (videoUrl != null
                             ? videoUrl.substring(0, Math.min(80, videoUrl.length())) : "null"));
 
-                    if (videoUrl == null && mutableMediaDictIntfClass != null && !carouselCandidates.isEmpty()) {
+                    if (videoUrl == null
+                            && (mutableMediaDictIntfClass != null || liveTreeMediaDictClass != null)
+                            && !carouselCandidates.isEmpty()) {
                         // A2: invoke every () -> List method; any that returns VideoVersionIntf items
                         //     is the video-versions list. Size >= 1 is enough (single video post).
-                        Object dictIntf = findFieldAssignableTo(media, mutableMediaDictIntfClass);
+                        Object dictIntf = findMediaDictionary(media);
                         if (dictIntf != null && videoVersionIntfClass != null && videoVersionGetUrl != null) {
                             outer:
                             for (Method candidate : carouselCandidates) {
@@ -445,7 +429,11 @@ public class FeedVideoDownloadHook {
                                         if (!videoVersionIntfClass.isInstance(item)) continue;
                                         try {
                                             String u = (String) videoVersionGetUrl.invoke(item);
-                                            if (u != null && isCdnMediaUrl(u)) { videoUrl = u; break outer; }
+                                            if (u != null && isCdnMediaUrl(u)) {
+                                                rememberVideoUrl(u);
+                                                videoUrl = u;
+                                                break outer;
+                                            }
                                         } catch (Throwable ignored) {}
                                     }
                                 } catch (Throwable ignored) {}
@@ -459,8 +447,9 @@ public class FeedVideoDownloadHook {
                     // ── Step B: Carousel detection ─────────────────────────────
                     // Try every () -> List method on MutableMediaDictIntf (and its direct
                     // superinterfaces) to find the carousel item list.
-                    if (mutableMediaDictIntfClass != null && !carouselCandidates.isEmpty()) {
-                        Object dictIntf = findFieldAssignableTo(media, mutableMediaDictIntfClass);
+                    if ((mutableMediaDictIntfClass != null || liveTreeMediaDictClass != null)
+                            && !carouselCandidates.isEmpty()) {
+                        Object dictIntf = findMediaDictionary(media);
                         ModuleLog.line("(IE|DL) dictIntf=" + (dictIntf != null
                                 ? dictIntf.getClass().getName() : "null"));
 
@@ -582,7 +571,10 @@ public class FeedVideoDownloadHook {
         if (videoVersionIntfClass.isInstance(obj)) {
             try {
                 String url = (String) videoVersionGetUrl.invoke(obj);
-                if (url != null && isCdnMediaUrl(url)) return url;
+                if (url != null && isCdnMediaUrl(url)) {
+                    rememberVideoUrl(url);
+                    return url;
+                }
             } catch (Throwable ignored) {}
         }
 
@@ -593,6 +585,7 @@ public class FeedVideoDownloadHook {
         while (cls != null && cls != Object.class) {
             for (Field f : cls.getDeclaredFields()) {
                 try {
+                    if (java.lang.reflect.Modifier.isStatic(f.getModifiers())) continue;
                     f.setAccessible(true);
                     Object val = f.get(obj);
                     if (val == null) continue;
@@ -603,7 +596,10 @@ public class FeedVideoDownloadHook {
                             if (elem != null && videoVersionIntfClass.isInstance(elem)) {
                                 try {
                                     String url = (String) videoVersionGetUrl.invoke(elem);
-                                    if (url != null && isCdnMediaUrl(url)) return url;
+                                    if (url != null && isCdnMediaUrl(url)) {
+                                        rememberVideoUrl(url);
+                                        return url;
+                                    }
                                 } catch (Throwable ignored) {}
                             }
                         }
@@ -628,15 +624,27 @@ public class FeedVideoDownloadHook {
      * Prefers m86 URLs (combined audio+video stream) — those are sorted to the front of the list.
      */
     static void collectAllVideoUrls(Object obj, List<String> out, Set<Object> visited, int depth) {
-        if (obj == null || depth > 5 || !visited.add(obj)) return;
-        if (videoVersionIntfClass == null || videoVersionGetUrl == null) return;
+        if (obj == null || depth > 7 || !visited.add(obj)) return;
 
-        if (videoVersionIntfClass.isInstance(obj)) {
-            try {
-                String url = (String) videoVersionGetUrl.invoke(obj);
-                if (url != null && isCdnMediaUrl(url) && !out.contains(url)) out.add(url);
-            } catch (Throwable ignored) {}
+        if (looksLikeVideoVersion(obj)) {
+            addVideoVersionUrl(obj, out);
             return; // don't recurse into VideoVersionIntf objects
+        }
+
+        if (obj instanceof Map<?, ?> map) {
+            for (Object value : map.values())
+                collectAllVideoUrls(value, out, visited, depth + 1);
+            return;
+        }
+        if (obj instanceof Iterable<?> iterable) {
+            for (Object value : iterable)
+                collectAllVideoUrls(value, out, visited, depth + 1);
+            return;
+        }
+        if (obj instanceof Object[] array) {
+            for (Object value : array)
+                collectAllVideoUrls(value, out, visited, depth + 1);
+            return;
         }
 
         Class<?> cls = obj.getClass();
@@ -646,17 +654,36 @@ public class FeedVideoDownloadHook {
         while (cls != null && cls != Object.class) {
             for (Field f : cls.getDeclaredFields()) {
                 try {
+                    if (java.lang.reflect.Modifier.isStatic(f.getModifiers())) continue;
                     f.setAccessible(true);
                     Object val = f.get(obj);
                     if (val == null) continue;
-                    if (val instanceof List<?> list) {
-                        for (Object elem : list)
-                            collectAllVideoUrls(elem, out, visited, depth + 1);
+                    String vcn = val.getClass().getName();
+                    if (val instanceof Iterable<?> || val instanceof Map<?, ?>
+                            || val instanceof Object[] || vcn.startsWith("X.")
+                            || vcn.startsWith("com.instagram.")
+                            || vcn.startsWith("com.facebook."))
+                        collectAllVideoUrls(val, out, visited, depth + 1);
+                } catch (Throwable ignored) {}
+            }
+            cls = cls.getSuperclass();
+        }
+
+        // Pando/LiveTree frequently keeps video_versions in native storage. Calling
+        // its no-arg List getter materializes the VideoVersion objects for inspection.
+        cls = obj.getClass();
+        while (cls != null && cls != Object.class) {
+            for (Method method : cls.getDeclaredMethods()) {
+                if (method.getParameterCount() != 0
+                        || !List.class.isAssignableFrom(method.getReturnType())) continue;
+                try {
+                    method.setAccessible(true);
+                    Object result = method.invoke(obj);
+                    if (!(result instanceof List<?> items) || items.isEmpty()) continue;
+                    if (isVideoVersionsList(items)) {
+                        for (Object item : items) addVideoVersionUrl(item, out);
                     } else {
-                        String vcn = val.getClass().getName();
-                        if (vcn.startsWith("X.") || vcn.startsWith("com.instagram.")
-                                || vcn.startsWith("com.facebook."))
-                            collectAllVideoUrls(val, out, visited, depth + 1);
+                        collectAllVideoUrls(items, out, visited, depth + 1);
                     }
                 } catch (Throwable ignored) {}
             }
@@ -664,14 +691,123 @@ public class FeedVideoDownloadHook {
         }
     }
 
+    private static boolean looksLikeVideoVersion(Object item) {
+        if (item == null) return false;
+        if (videoVersionIntfClass != null && videoVersionIntfClass.isInstance(item)) return true;
+        String name = item.getClass().getName().toLowerCase(Locale.US);
+        return name.contains("videoversion") || name.contains("video_version");
+    }
+
+    private static boolean isVideoVersionsList(List<?> items) {
+        int checked = 0;
+        for (Object item : items) {
+            if (item == null) continue;
+            checked++;
+            if (!looksLikeVideoVersion(item)) return false;
+        }
+        return checked > 0;
+    }
+
+    private static void addVideoVersionUrl(Object item, List<String> out) {
+        String url = videoUrlFromVersionObject(item);
+        if (url == null) return;
+        rememberVideoUrl(url);
+        if (!out.contains(url)) out.add(url);
+    }
+
     /** Returns the best video URL from the media object: prefers m86 (combined stream). */
     static String bestVideoUrlFromMedia(Object media) {
-        Set<Object> visited = Collections.newSetFromMap(new IdentityHashMap<>());
         List<String> all = new ArrayList<>();
-        collectAllVideoUrls(media, all, visited, 0);
+        collectVideoUrlsFromDictionary(media, all);
+        if (all.isEmpty()) {
+            Set<Object> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+            collectAllVideoUrls(media, all, visited, 0);
+        }
         if (all.isEmpty()) return null;
         for (String u : all) { if (u.contains("/m86/") || u.contains("%2Fm86%2F")) return u; }
         return all.get(0); // fallback: first found
+    }
+
+    static boolean isMediaVideo(Object media) {
+        if (media == null || resolvedIsVideoMethod == null) return false;
+        try {
+            Object target = resolvedIsVideoMethod.getDeclaringClass().isInstance(media)
+                    ? media
+                    : MediaModelResolver.findObjectOfType(
+                            media, resolvedIsVideoMethod.getDeclaringClass(), 5);
+            if (target == null) return false;
+            Object result = resolvedIsVideoMethod.invoke(target);
+            return result instanceof Boolean && (Boolean) result;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
+    /**
+     * Invokes the Pando-backed video_versions accessor. These values often do not exist as
+     * Java fields until the JNI getter is called, so the regular object-graph walk misses
+     * them on current Instagram builds.
+     */
+    private static void collectVideoUrlsFromDictionary(Object media, List<String> out) {
+        for (Method getter : resolvedVideoVersionsGetters) {
+            Object owner = getter.getDeclaringClass().isInstance(media)
+                    ? media
+                    : MediaModelResolver.findObjectOfType(media, getter.getDeclaringClass(), 7);
+            if (owner != null) collectUrlsFromVideoVersionsMethod(owner, getter, out, true);
+        }
+
+        // Structural fallback for builds where DexKit cannot identify video_versions:
+        // only accept a list when every URL-bearing item resolves to a video URL.
+        Object dict = findMediaDictionary(media);
+        if (dict == null) return;
+        for (Method candidate : carouselCandidates) {
+            if (resolvedVideoVersionsGetters.contains(candidate)) continue;
+            Object owner = candidate.getDeclaringClass().isInstance(dict)
+                    ? dict
+                    : MediaModelResolver.findObjectOfType(media, candidate.getDeclaringClass(), 5);
+            if (owner != null) collectUrlsFromVideoVersionsMethod(owner, candidate, out, false);
+        }
+    }
+
+    private static void collectUrlsFromVideoVersionsMethod(Object dict, Method getter,
+                                                            List<String> out,
+                                                            boolean trustedVideoList) {
+        try {
+            Object result = getter.invoke(dict);
+            if (!(result instanceof List<?> items) || items.isEmpty()) return;
+
+            List<String> found = new ArrayList<>();
+            for (Object item : items) {
+                String url = videoUrlFromVersionObject(item);
+                if (url == null) continue;
+                if (trustedVideoList || isVideoUrl(url)) found.add(url);
+            }
+            if (!trustedVideoList && (found.isEmpty() || found.size() != items.size())) return;
+            for (String url : found) {
+                rememberVideoUrl(url);
+                if (!out.contains(url)) out.add(url);
+            }
+        } catch (Throwable ignored) {}
+    }
+
+    private static String videoUrlFromVersionObject(Object item) {
+        if (item == null) return null;
+        if (videoVersionIntfClass != null && videoVersionGetUrl != null
+                && videoVersionIntfClass.isInstance(item)) {
+            try {
+                Object result = videoVersionGetUrl.invoke(item);
+                if (result instanceof String url && isCdnMediaUrl(url)) {
+                    rememberVideoUrl(url);
+                    return url;
+                }
+            } catch (Throwable ignored) {}
+        }
+        String url = tryGetUrl(item);
+        if (url != null && isCdnMediaUrl(url)) {
+            rememberVideoUrl(url);
+            return url;
+        }
+        return null;
     }
 
     /**
@@ -820,6 +956,15 @@ public class FeedVideoDownloadHook {
         return null;
     }
 
+    private static Object findMediaDictionary(Object media) {
+        if (mediaModel != null) {
+            Object dict = MediaModelResolver.findDictionary(media, mediaModel, 3);
+            if (dict != null) return dict;
+        }
+        Object dict = findFieldAssignableTo(media, liveTreeMediaDictClass);
+        return dict != null ? dict : findFieldAssignableTo(media, mutableMediaDictIntfClass);
+    }
+
     // ── Buffer helpers ────────────────────────────────────────────────────────
 
     private static List<String> snapshotUrlsSince(long from) {
@@ -844,6 +989,26 @@ public class FeedVideoDownloadHook {
         return r;
     }
 
+    static void rememberVideoUrl(String url) {
+        if (url == null || !isCdnMediaUrl(url)) return;
+        synchronized (videoUrlBuffer) {
+            if (!videoUrlBuffer.isEmpty() && videoUrlBuffer.peekFirst().url.equals(url)) return;
+            videoUrlBuffer.removeIf(entry -> entry.url.equals(url));
+            videoUrlBuffer.addFirst(new UrlEntry(url));
+            while (videoUrlBuffer.size() > MAX_URLS) videoUrlBuffer.removeLast();
+        }
+    }
+
+    private static boolean wasCapturedAsVideo(String url) {
+        if (url == null) return false;
+        synchronized (videoUrlBuffer) {
+            for (UrlEntry entry : videoUrlBuffer) {
+                if (entry.url.equals(url)) return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * DexKit-based hook on {@code VideoVersionIntf.getUrl()} — installed once at startup.
      *
@@ -855,6 +1020,9 @@ public class FeedVideoDownloadHook {
      * Used as a supplement to the Uri.parse buffer (Tier 3) when Tiers 1 and 2 fail.
      */
     public static void installVideoUrlCaptureHook(DexKitBridge bridge, ClassLoader classLoader) {
+        discoverDynamicMediaModel(bridge, classLoader);
+        resolveVideoVersionsGetters(bridge, classLoader);
+        resolveIsVideoMethod(bridge, classLoader);
         XC_MethodHook urlHook = new XC_MethodHook() {
             @Override
             protected void afterHookedMethod(MethodHookParam param) {
@@ -862,11 +1030,7 @@ public class FeedVideoDownloadHook {
                 Object result = param.getResult();
                 if (!(result instanceof String url)) return;
                 if (!isCdnMediaUrl(url)) return;
-                synchronized (videoUrlBuffer) {
-                    if (!videoUrlBuffer.isEmpty() && videoUrlBuffer.peekFirst().url.equals(url)) return;
-                    videoUrlBuffer.addFirst(new UrlEntry(url));
-                    while (videoUrlBuffer.size() > MAX_URLS) videoUrlBuffer.removeLast();
-                }
+                rememberVideoUrl(url);
             }
         };
 
@@ -922,6 +1086,141 @@ public class FeedVideoDownloadHook {
         }
 
         resolveUsernameGetter(bridge, classLoader);
+    }
+
+    private static void discoverDynamicMediaModel(DexKitBridge bridge, ClassLoader classLoader) {
+        try {
+            Class<?> discovered = null;
+            if (DexKitCache.isCacheValid()) {
+                String className = DexKitCache.loadString("MediaDownload_DictClass");
+                if (className != null) {
+                    try { discovered = classLoader.loadClass(className); } catch (Throwable ignored) {}
+                }
+            }
+            if (discovered == null && liveTreeMediaDictClass == null) {
+                List<ClassData> classes = bridge.findClass(FindClass.create()
+                        .matcher(ClassMatcher.create()
+                                .usingStrings("video_to_carousel_cut_info")));
+                for (ClassData data : classes) {
+                    try {
+                        boolean selfBacked = false;
+                        for (org.luckypray.dexkit.result.FieldData field : data.getFields()) {
+                            if (data.getName().equals(field.getTypeName())) {
+                                selfBacked = true;
+                                break;
+                            }
+                        }
+                        if (!selfBacked) continue;
+                        Class<?> candidate = data.getInstance(classLoader);
+                        if (!candidate.isInterface()) {
+                            discovered = candidate;
+                            DexKitCache.saveString("MediaDownload_DictClass", candidate.getName());
+                            break;
+                        }
+                    } catch (Throwable ignored) {}
+                }
+            }
+            mediaModel = MediaModelResolver.resolve(classLoader, discovered);
+            mutableMediaDictIntfClass = mediaModel.mutableDictClass;
+            liveTreeMediaDictClass = mediaModel.liveTreeDictClass;
+            carouselCandidates.clear();
+            carouselCandidates.addAll(mediaModel.listCandidates);
+            ModuleLog.line("(IE|DL|DexKit) dynamic media dict="
+                    + (liveTreeMediaDictClass == null ? "not found" : liveTreeMediaDictClass.getName()));
+        } catch (Throwable t) {
+            ModuleLog.line("(IE|DL|DexKit) dynamic media model resolution failed: " + t);
+        }
+    }
+
+    private static void resolveVideoVersionsGetters(DexKitBridge bridge, ClassLoader classLoader) {
+        resolvedVideoVersionsGetters.clear();
+        try {
+            if (DexKitCache.isCacheValid()) {
+                List<Method> cached = DexKitCache.loadMethods(
+                        "MediaDownload_VideoVersionsGetters", classLoader);
+                if (cached != null) resolvedVideoVersionsGetters.addAll(cached);
+                if (resolvedVideoVersionsGetters.isEmpty()) {
+                    Method legacyCached = DexKitCache.loadMethod(
+                            "MediaDownload_VideoVersionsGetter", classLoader);
+                    if (legacyCached != null) resolvedVideoVersionsGetters.add(legacyCached);
+                }
+            }
+
+            if (resolvedVideoVersionsGetters.isEmpty()) {
+                List<MethodData> results = bridge.findMethod(FindMethod.create()
+                        .matcher(MethodMatcher.create()
+                                .paramCount(0)
+                                .usingEqStrings(List.of("video_versions"))));
+                Set<String> seen = new HashSet<>();
+                for (MethodData methodData : results) {
+                    try {
+                        Method method = methodData.getMethodInstance(classLoader);
+                        if (!List.class.isAssignableFrom(method.getReturnType())) continue;
+                        String key = method.getDeclaringClass().getName() + '#' + method.getName();
+                        if (!seen.add(key)) continue;
+                        method.setAccessible(true);
+                        resolvedVideoVersionsGetters.add(method);
+                    } catch (Throwable ignored) {}
+                }
+                if (!resolvedVideoVersionsGetters.isEmpty()) {
+                    DexKitCache.saveMethods("MediaDownload_VideoVersionsGetters",
+                            resolvedVideoVersionsGetters);
+                }
+            }
+
+            if (liveTreeMediaDictClass == null && !resolvedVideoVersionsGetters.isEmpty()) {
+                Class<?> discovered = resolvedVideoVersionsGetters.get(0).getDeclaringClass();
+                mediaModel = MediaModelResolver.resolve(classLoader, discovered);
+                mutableMediaDictIntfClass = mediaModel.mutableDictClass;
+                liveTreeMediaDictClass = mediaModel.liveTreeDictClass;
+                carouselCandidates.clear();
+                carouselCandidates.addAll(mediaModel.listCandidates);
+                DexKitCache.saveString("MediaDownload_DictClass", discovered.getName());
+            }
+
+            for (Method getter : resolvedVideoVersionsGetters) {
+                if (!carouselCandidates.contains(getter)) carouselCandidates.add(getter);
+            }
+            ModuleLog.line("(IE|DL|DexKit) video_versions getters="
+                    + resolvedVideoVersionsGetters.size());
+        } catch (Throwable t) {
+            ModuleLog.line("(IE|DL|DexKit) video_versions getter resolution failed: " + t);
+        }
+    }
+
+    private static void resolveIsVideoMethod(DexKitBridge bridge, ClassLoader classLoader) {
+        try {
+            if (DexKitCache.isCacheValid()) {
+                resolvedIsVideoMethod = DexKitCache.loadMethod(
+                        "MediaDownload_IsVideo", classLoader);
+            }
+            if (resolvedIsVideoMethod == null) {
+                List<MethodData> wrappers = bridge.findMethod(FindMethod.create()
+                        .matcher(MethodMatcher.create()
+                                .returnType("void")
+                                .usingStrings("asl_session_id", "is_video", "is_carousel")));
+                for (MethodData wrapper : wrappers) {
+                    for (MethodData invoked : wrapper.getInvokes()) {
+                        if (invoked.getParamCount() != 0
+                                || !"boolean".equals(invoked.getReturnTypeName())) continue;
+                        if (mediaClass != null
+                                && !mediaClass.getName().equals(invoked.getDeclaredClassName())) continue;
+                        try {
+                            Method method = invoked.getMethodInstance(classLoader);
+                            method.setAccessible(true);
+                            resolvedIsVideoMethod = method;
+                            DexKitCache.saveMethod("MediaDownload_IsVideo", method);
+                            break;
+                        } catch (Throwable ignored) {}
+                    }
+                    if (resolvedIsVideoMethod != null) break;
+                }
+            }
+            ModuleLog.line("(IE|DL|DexKit) isVideo="
+                    + (resolvedIsVideoMethod == null ? "not found" : resolvedIsVideoMethod.getName()));
+        } catch (Throwable t) {
+            ModuleLog.line("(IE|DL|DexKit) isVideo resolution failed: " + t);
+        }
     }
 
     /**
@@ -990,7 +1289,8 @@ public class FeedVideoDownloadHook {
     }
 
     private static void resolveDictUserGetter(DexKitBridge bridge, ClassLoader classLoader) {
-        if (mutableMediaDictIntfClass == null || userClass == null) return;
+        if ((mutableMediaDictIntfClass == null && liveTreeMediaDictClass == null)
+                || userClass == null) return;
 
         if (DexKitCache.isCacheValid()) {
             Method cached = DexKitCache.loadMethod("DictUserGetter", classLoader);
@@ -1004,7 +1304,7 @@ public class FeedVideoDownloadHook {
         // Instagram 423+ often hides this in a parent interface like X.IdM
         Deque<Class<?>> queue = new ArrayDeque<>();
         Set<Class<?>> visited = new HashSet<>();
-        queue.add(mutableMediaDictIntfClass);
+        if (mutableMediaDictIntfClass != null) queue.add(mutableMediaDictIntfClass);
 
         while (!queue.isEmpty()) {
             Class<?> curr = queue.poll();
@@ -1034,24 +1334,26 @@ public class FeedVideoDownloadHook {
         // post's actual author. Use DexKit to find the specific one that checks the
         // generic Pando "user" field (the one Instagram's own code uses for post
         // authorship, e.g. QpF's own-post check) rather than "owner"/"group"/etc.
-        try {
-            List<MethodData> results = bridge.findMethod(FindMethod.create()
-                    .matcher(MethodMatcher.create()
-                            .declaredClass("com.instagram.feed.media.LiveTreeMediaDict")
-                            .paramCount(0)
-                            .returnType(userClass)
-                            .usingEqStrings(java.util.List.of("user"))));
+        if (liveTreeMediaDictClass != null) {
+            try {
+                List<MethodData> results = bridge.findMethod(FindMethod.create()
+                        .matcher(MethodMatcher.create()
+                                .declaredClass(liveTreeMediaDictClass.getName())
+                                .paramCount(0)
+                                .returnType(userClass)
+                                .usingEqStrings(java.util.List.of("user"))));
 
-            if (!results.isEmpty()) {
-                Method m = results.get(0).getMethodInstance(classLoader);
-                m.setAccessible(true);
-                dictUserGetter = m;
-                DexKitCache.saveMethod("DictUserGetter", m);
-                ModuleLog.line("(IE|DL|Username) ✅ Resolved dictUserGetter (concrete class): " + m.getName());
-                return;
+                if (!results.isEmpty()) {
+                    Method m = results.get(0).getMethodInstance(classLoader);
+                    m.setAccessible(true);
+                    dictUserGetter = m;
+                    DexKitCache.saveMethod("DictUserGetter", m);
+                    ModuleLog.line("(IE|DL|Username) ✅ Resolved dictUserGetter (concrete class): " + m.getName());
+                    return;
+                }
+            } catch (Throwable t) {
+                ModuleLog.line("(IE|DL|Username) ❌ dictUserGetter DexKit lookup: " + t);
             }
-        } catch (Throwable t) {
-            ModuleLog.line("(IE|DL|Username) ❌ dictUserGetter DexKit lookup: " + t);
         }
 
         ModuleLog.line("(IE|DL|Username) ❌ Failed to resolve dictUserGetter in hierarchy");
@@ -1090,9 +1392,10 @@ public class FeedVideoDownloadHook {
         if (media == null) return null;
 
         // TIER 1: Use the resolved Dictionary Getter
-        if (dictUserGetter != null && mutableMediaDictIntfClass != null) {
+        if (dictUserGetter != null
+                && (mutableMediaDictIntfClass != null || liveTreeMediaDictClass != null)) {
             try {
-                Object dictIntf = findFieldAssignableTo(media, mutableMediaDictIntfClass);
+                Object dictIntf = findMediaDictionary(media);
                 if (dictIntf != null) {
                     Object userObj = dictUserGetter.invoke(dictIntf);
                     if (userObj != null) {
@@ -1354,9 +1657,21 @@ public class FeedVideoDownloadHook {
             return true;
         }
 
-        // No custom folder configured → MediaStore / raw path.
-        try (OutputStream out = openOutputStream(ctx, filename, isVideo, username)) {
-            downloadToStream(url, out);
+        // No custom folder configured → download to a neutral temporary file first.
+        // The response and file signature decide the final MIME/extension; CDN URL text
+        // alone is not reliable on recent Instagram versions.
+        File temp = File.createTempFile("ie_dl_", ".bin", ctx.getCacheDir());
+        try {
+            String responseType = downloadToFileAndGetType(url, temp);
+            MediaTypeDetector.Result detected = MediaTypeDetector.resolve(
+                    temp, responseType, isVideo ? "video/mp4" : "image/jpeg", filename);
+            ModuleLog.line("(IE|DL|Type) requested=" + (isVideo ? "video" : "image")
+                    + " response=" + responseType + " detected=" + detected.kind
+                    + " file=" + detected.filename);
+            saveFileToDestination(ctx, temp, detected.filename, detected.isVideo(), username);
+        } finally {
+            //noinspection ResultOfMethodCallIgnored
+            temp.delete();
         }
         return false;
     }
@@ -1426,8 +1741,9 @@ public class FeedVideoDownloadHook {
                 " carouselCandidates=" + carouselCandidates.size());
 
         // Step B: carousel (MutableMediaDictIntf candidates)
-        if (mutableMediaDictIntfClass != null && !carouselCandidates.isEmpty()) {
-            Object dictIntf = findFieldAssignableTo(media, mutableMediaDictIntfClass);
+        if ((mutableMediaDictIntfClass != null || liveTreeMediaDictClass != null)
+                && !carouselCandidates.isEmpty()) {
+            Object dictIntf = findMediaDictionary(media);
             ModuleLog.line("(IE|Post|DEBUG) dictIntf=" +
                     (dictIntf == null ? "null" : dictIntf.getClass().getName()));
             if (dictIntf != null) {
@@ -1466,6 +1782,22 @@ public class FeedVideoDownloadHook {
                     } catch (Throwable ignored) {}
                 }
             }
+        }
+
+        // A Reel/video must never fall through to its image_versions2 cover. If exact
+        // model extraction failed, only accept a URL that belongs to this media object's
+        // own graph and was independently identified as video.
+        if (isMediaVideo(media)) {
+            List<String> mediaUrls = collectCdnUrls(media);
+            for (String candidate : mediaUrls) {
+                if (isVideoUrl(candidate)) {
+                    rememberVideoUrl(candidate);
+                    return new ArrayList<>(List.of(candidate));
+                }
+            }
+            ModuleLog.line("(IE|Post|DL) media is video but no video URL was resolved; "
+                    + "refusing image cover fallback");
+            return new ArrayList<>();
         }
 
         // Step C: single photo
@@ -1692,9 +2024,10 @@ public class FeedVideoDownloadHook {
      * using the DexKit-resolved dictUserGetter. Used by StoryDownloadHook.
      */
     static String extractUsernameFromMediaObject(Object media) {
-        if (media == null || dictUserGetter == null || mutableMediaDictIntfClass == null) return null;
+        if (media == null || dictUserGetter == null
+                || (mutableMediaDictIntfClass == null && liveTreeMediaDictClass == null)) return null;
         try {
-            Object dictIntf = findFieldAssignableTo(media, mutableMediaDictIntfClass);
+            Object dictIntf = findMediaDictionary(media);
             if (dictIntf == null) return null;
             Object user = dictUserGetter.invoke(dictIntf);
             return UserUtils.callUsernameGetter(user);
@@ -1925,13 +2258,19 @@ public class FeedVideoDownloadHook {
     }
 
     private static void downloadToFile(String url, File dest) throws Exception {
+        downloadToFileAndGetType(url, dest);
+    }
+
+    private static String downloadToFileAndGetType(String url, File dest) throws Exception {
         HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
         conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Linux; Android 12) AppleWebKit/537.36");
         conn.connect();
+        String contentType = conn.getContentType();
         try (InputStream in = conn.getInputStream(); FileOutputStream fos = new FileOutputStream(dest)) {
             byte[] buf = new byte[32768]; int n;
             while ((n = in.read(buf)) != -1) fos.write(buf, 0, n);
         } finally { conn.disconnect(); }
+        return contentType;
     }
 
     static void downloadToStream(String url, OutputStream out) throws Exception {
@@ -2037,13 +2376,21 @@ public class FeedVideoDownloadHook {
      *   /o1/v/t2/ = background music track for Reels
      */
     static boolean isVideoUrl(String url) {
+        if (url == null) return false;
+        // Source-aware classification: a URL returned by VideoVersionIntf or by the
+        // Pando video_versions getter is a video even when the CDN path is opaque.
+        if (wasCapturedAsVideo(url)) return true;
+        String lower = url.toLowerCase(Locale.US);
         // All Instagram video CDN path segments begin with t50.
         // Covers all variants: t50.2886-16, t50.29441-2, t50.16800-16, etc.
-        if (url.contains("t50.")) return true;
+        if (lower.contains("t50.")) return true;
         // Reels/Clips CDN paths use /o1/ regardless of whether they carry a t50 segment.
         // Note: /o1/v/t2/ is NOT audio-only — it is the standard Reels progressive MP4 path.
-        if (url.contains("/o1/")) return true;
-        return false;
+        if (lower.contains("/o1/") || lower.contains("%2fo1%2f")) return true;
+        // Newer CDN variants may omit t50/o1 while retaining the explicit container or MIME.
+        return lower.contains(".mp4")
+                || lower.contains("mime_type=video")
+                || lower.contains("mime%2ftype=video");
     }
 
     private static boolean hasAncestorWithId(View view, int targetId) {

--- a/app/src/main/java/ps/reso/instaeclipse/mods/media/MediaModelResolver.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/media/MediaModelResolver.java
@@ -1,0 +1,178 @@
+package ps.reso.instaeclipse.mods.media;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Resolves Instagram's legacy and modern media dictionary models independently. */
+final class MediaModelResolver {
+
+    static final String MUTABLE_DICT_CLASS = "com.instagram.feed.media.MutableMediaDictIntf";
+    static final String LIVE_TREE_DICT_CLASS = "com.instagram.feed.media.LiveTreeMediaDict";
+
+    static final class Result {
+        final Class<?> mutableDictClass;
+        final Class<?> liveTreeDictClass;
+        final List<Method> listCandidates;
+
+        Result(Class<?> mutableDictClass, Class<?> liveTreeDictClass,
+               List<Method> listCandidates) {
+            this.mutableDictClass = mutableDictClass;
+            this.liveTreeDictClass = liveTreeDictClass;
+            this.listCandidates = listCandidates;
+        }
+    }
+
+    private MediaModelResolver() {}
+
+    static Result resolve(ClassLoader classLoader) {
+        return resolve(classLoader, null);
+    }
+
+    static Result resolve(ClassLoader classLoader, Class<?> discoveredDictClass) {
+        Class<?> mutable = tryLoad(classLoader, MUTABLE_DICT_CLASS);
+        Class<?> liveTree = tryLoad(classLoader, LIVE_TREE_DICT_CLASS);
+        if (liveTree == null) liveTree = discoveredDictClass;
+        List<Method> candidates = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+
+        if (mutable != null) {
+            addListMethods(mutable, candidates, seen);
+            for (Class<?> superInterface : mutable.getInterfaces()) {
+                if (isInstagramModelClass(superInterface.getName())) {
+                    addListMethods(superInterface, candidates, seen);
+                }
+            }
+        }
+
+        // Never nest this lookup under MutableMediaDictIntf. Recent Instagram versions
+        // can remove the legacy interface while retaining the concrete Pando model.
+        if (liveTree != null) addListMethods(liveTree, candidates, seen);
+        return new Result(mutable, liveTree, candidates);
+    }
+
+    static Object findDictionary(Object media, Result model, int maxDepth) {
+        if (media == null || model == null || maxDepth < 0) return null;
+        Set<Object> visited = java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+        Object found = findObjectOfType(media, model.liveTreeDictClass, maxDepth, visited);
+        if (found != null) return found;
+        visited.clear();
+        return findObjectOfType(media, model.mutableDictClass, maxDepth, visited);
+    }
+
+    static Object findObjectOfType(Object root, Class<?> target, int maxDepth) {
+        Set<Object> visited = java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+        return findObjectOfType(root, target, maxDepth, visited);
+    }
+
+    private static Object findObjectOfType(Object obj, Class<?> target, int depth,
+                                           Set<Object> visited) {
+        if (obj == null || target == null || depth < 0 || !visited.add(obj)) return null;
+        if (target.isInstance(obj)) return obj;
+
+        if (obj instanceof Map<?, ?> map) {
+            if (depth == 0) return null;
+            for (Object value : map.values()) {
+                Object nested = findObjectOfType(value, target, depth - 1, visited);
+                if (nested != null) return nested;
+            }
+            return null;
+        }
+        if (obj instanceof Iterable<?> iterable) {
+            if (depth == 0) return null;
+            for (Object value : iterable) {
+                Object nested = findObjectOfType(value, target, depth - 1, visited);
+                if (nested != null) return nested;
+            }
+            return null;
+        }
+        if (obj instanceof Object[] array) {
+            if (depth == 0) return null;
+            for (Object value : array) {
+                Object nested = findObjectOfType(value, target, depth - 1, visited);
+                if (nested != null) return nested;
+            }
+            return null;
+        }
+
+        Class<?> cls = obj.getClass();
+        while (cls != null && cls != Object.class) {
+            for (Field field : cls.getDeclaredFields()) {
+                try {
+                    if (java.lang.reflect.Modifier.isStatic(field.getModifiers())) continue;
+                    field.setAccessible(true);
+                    Object value = field.get(obj);
+                    if (value == null) continue;
+                    if (target.isInstance(value)) return value;
+                    boolean traversable = isInstagramModelClass(value.getClass().getName())
+                            || value instanceof Iterable<?> || value instanceof Map<?, ?>
+                            || value instanceof Object[];
+                    if (depth == 0 || !traversable) continue;
+                    Object nested = findObjectOfType(value, target, depth - 1, visited);
+                    if (nested != null) return nested;
+                } catch (Throwable ignored) {}
+            }
+            cls = cls.getSuperclass();
+        }
+
+        // Some Pando models expose their backing node only through a no-arg getter.
+        // Probe model-returning getters after the field walk, with the same depth limit.
+        if (depth > 0 && isInstagramModelClass(obj.getClass().getName())) {
+            cls = obj.getClass();
+            while (cls != null && cls != Object.class) {
+                for (Method method : cls.getDeclaredMethods()) {
+                    if (method.getParameterCount() != 0
+                            || java.lang.reflect.Modifier.isStatic(method.getModifiers())) continue;
+                    Class<?> returnType = method.getReturnType();
+                    if (returnType.isPrimitive() || returnType == String.class
+                            || returnType == Class.class) continue;
+                    if (!target.isAssignableFrom(returnType)
+                            && !isInstagramModelClass(returnType.getName())
+                            && !Collection.class.isAssignableFrom(returnType)
+                            && !Map.class.isAssignableFrom(returnType)) continue;
+                    try {
+                        method.setAccessible(true);
+                        Object value = method.invoke(obj);
+                        Object nested = findObjectOfType(value, target, depth - 1, visited);
+                        if (nested != null) return nested;
+                    } catch (Throwable ignored) {}
+                }
+                cls = cls.getSuperclass();
+            }
+        }
+        return null;
+    }
+
+    private static Class<?> tryLoad(ClassLoader classLoader, String name) {
+        try {
+            return classLoader.loadClass(name);
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    private static void addListMethods(Class<?> type, List<Method> out, Set<String> seen) {
+        for (Method method : type.getDeclaredMethods()) {
+            if (method.getParameterCount() != 0
+                    || !List.class.isAssignableFrom(method.getReturnType())) continue;
+            String key = method.getDeclaringClass().getName() + '#' + method.getName()
+                    + ':' + method.getReturnType().getName();
+            if (!seen.add(key)) continue;
+            try { method.setAccessible(true); } catch (Throwable ignored) {}
+            out.add(method);
+        }
+    }
+
+    private static boolean isInstagramModelClass(String name) {
+        return name.startsWith("X.")
+                || name.startsWith("com.instagram.")
+                || name.startsWith("com.facebook.")
+                || name.startsWith("ps.reso.instaeclipse.mods.media.");
+    }
+}

--- a/app/src/main/java/ps/reso/instaeclipse/mods/media/MediaTypeDetector.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/media/MediaTypeDetector.java
@@ -1,0 +1,128 @@
+package ps.reso.instaeclipse.mods.media;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Locale;
+
+/** Detects downloaded media from its response header and file signature. */
+final class MediaTypeDetector {
+
+    enum Kind { VIDEO, IMAGE, UNKNOWN }
+
+    static final class Result {
+        final Kind kind;
+        final String mimeType;
+        final String filename;
+
+        Result(Kind kind, String mimeType, String filename) {
+            this.kind = kind;
+            this.mimeType = mimeType;
+            this.filename = filename;
+        }
+
+        boolean isVideo() {
+            return kind == Kind.VIDEO;
+        }
+    }
+
+    private MediaTypeDetector() {}
+
+    static Result resolve(File file, String responseContentType, String requestedMime,
+                          String requestedFilename) throws IOException {
+        Kind kind = sniff(file);
+        if (kind == Kind.UNKNOWN) kind = fromContentType(responseContentType);
+        if (kind == Kind.UNKNOWN) kind = fromContentType(requestedMime);
+
+        String mime = kind == Kind.VIDEO ? "video/mp4"
+                : kind == Kind.IMAGE ? "image/jpeg"
+                : normalizeContentType(requestedMime);
+        if (mime == null || mime.isEmpty()) mime = "application/octet-stream";
+        return new Result(kind, mime, withCorrectExtension(requestedFilename, kind));
+    }
+
+    static Kind fromContentType(String contentType) {
+        String normalized = normalizeContentType(contentType);
+        if (normalized == null) return Kind.UNKNOWN;
+        if (normalized.startsWith("video/")) return Kind.VIDEO;
+        if (normalized.startsWith("image/")) return Kind.IMAGE;
+        return Kind.UNKNOWN;
+    }
+
+    static String withCorrectExtension(String filename, Kind kind) {
+        if (filename == null || filename.isEmpty() || kind == Kind.UNKNOWN) return filename;
+        String wanted = kind == Kind.VIDEO ? ".mp4" : ".jpg";
+        String lower = filename.toLowerCase(Locale.US);
+        if (lower.endsWith(wanted)) return filename;
+
+        int slash = Math.max(filename.lastIndexOf('/'), filename.lastIndexOf('\\'));
+        int dot = filename.lastIndexOf('.');
+        if (dot > slash) return filename.substring(0, dot) + wanted;
+        return filename + wanted;
+    }
+
+    static Kind sniff(File file) throws IOException {
+        try (InputStream in = new FileInputStream(file)) {
+            byte[] header = new byte[16];
+            int read = 0;
+            while (read < header.length) {
+                int n = in.read(header, read, header.length - read);
+                if (n < 0) break;
+                read += n;
+            }
+            return sniff(header, read);
+        }
+    }
+
+    static Kind sniff(byte[] header, int length) {
+        if (header == null || length < 3) return Kind.UNKNOWN;
+
+        if (u(header[0]) == 0xff && u(header[1]) == 0xd8 && u(header[2]) == 0xff) {
+            return Kind.IMAGE;
+        }
+        if (length >= 8
+                && u(header[0]) == 0x89 && header[1] == 'P' && header[2] == 'N'
+                && header[3] == 'G' && u(header[4]) == 0x0d && u(header[5]) == 0x0a
+                && u(header[6]) == 0x1a && u(header[7]) == 0x0a) {
+            return Kind.IMAGE;
+        }
+        if (length >= 6 && header[0] == 'G' && header[1] == 'I' && header[2] == 'F'
+                && header[3] == '8' && (header[4] == '7' || header[4] == '9')
+                && header[5] == 'a') {
+            return Kind.IMAGE;
+        }
+        if (length >= 12 && header[0] == 'R' && header[1] == 'I' && header[2] == 'F'
+                && header[3] == 'F' && header[8] == 'W' && header[9] == 'E'
+                && header[10] == 'B' && header[11] == 'P') {
+            return Kind.IMAGE;
+        }
+
+        // MP4 and HEIF/AVIF share ISO-BMFF's ftyp box. Inspect the major brand so
+        // still images are not mislabeled as video.
+        if (length >= 12 && header[4] == 'f' && header[5] == 't'
+                && header[6] == 'y' && header[7] == 'p') {
+            String brand = new String(header, 8, 4, java.nio.charset.StandardCharsets.US_ASCII)
+                    .toLowerCase(Locale.US);
+            if (brand.equals("heic") || brand.equals("heix") || brand.equals("hevc")
+                    || brand.equals("hevx") || brand.equals("mif1") || brand.equals("msf1")
+                    || brand.equals("avif") || brand.equals("avis")) {
+                return Kind.IMAGE;
+            }
+            return Kind.VIDEO;
+        }
+        return Kind.UNKNOWN;
+    }
+
+    private static String normalizeContentType(String contentType) {
+        if (contentType == null) return null;
+        int semicolon = contentType.indexOf(';');
+        String normalized = (semicolon >= 0 ? contentType.substring(0, semicolon) : contentType)
+                .trim().toLowerCase(Locale.US);
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private static int u(byte value) {
+        return value & 0xff;
+    }
+}

--- a/app/src/main/java/ps/reso/instaeclipse/mods/media/StoryDownloadChoicePolicy.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/media/StoryDownloadChoicePolicy.java
@@ -1,0 +1,24 @@
+package ps.reso.instaeclipse.mods.media;
+
+/** Pure decision policy for Story download variants. */
+final class StoryDownloadChoicePolicy {
+
+    enum Decision {
+        NOT_FOUND,
+        DOWNLOAD_PHOTO,
+        DOWNLOAD_VIDEO,
+        ASK
+    }
+
+    private StoryDownloadChoicePolicy() {}
+
+    static Decision decide(boolean hasImage, boolean hasVideo, boolean modelSaysVideo) {
+        if (hasImage && hasVideo) return Decision.ASK;
+        if (hasVideo) return Decision.DOWNLOAD_VIDEO;
+
+        // If Instagram identifies the Story as video but only a cover was resolved,
+        // require an explicit photo choice instead of silently saving it as an MP4.
+        if (hasImage) return modelSaysVideo ? Decision.ASK : Decision.DOWNLOAD_PHOTO;
+        return Decision.NOT_FOUND;
+    }
+}

--- a/app/src/main/java/ps/reso/instaeclipse/mods/media/StoryDownloadHook.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/media/StoryDownloadHook.java
@@ -1,5 +1,6 @@
 package ps.reso.instaeclipse.mods.media;
 
+import android.app.AlertDialog;
 import android.app.AndroidAppHelper;
 import android.content.Context;
 import android.os.Handler;
@@ -39,9 +40,27 @@ public class StoryDownloadHook {
 
     private static final Handler mainHandler = new Handler(Looper.getMainLooper());
 
-    // Username + media ID resolved at download trigger time
-    private volatile String currentStoryUsername = null;
-    private volatile String currentStoryMediaId  = null;
+    private static final class StoryMedia {
+        final String url;
+        final boolean video;
+
+        StoryMedia(String url, boolean video) {
+            this.url = url;
+            this.video = video;
+        }
+    }
+
+    private static final class StoryMediaOptions {
+        final String imageUrl;
+        final String videoUrl;
+        final boolean modelSaysVideo;
+
+        StoryMediaOptions(String imageUrl, String videoUrl, boolean modelSaysVideo) {
+            this.imageUrl = imageUrl;
+            this.videoUrl = videoUrl;
+            this.modelSaysVideo = modelSaysVideo;
+        }
+    }
 
     // ── Entry point ──────────────────────────────────────────────────────────
 
@@ -187,18 +206,20 @@ public class StoryDownloadHook {
                     }
 
                     // 5. Extract story URL via ReelItem → media object field graph
-                    String url = extractStoryUrl(holder != null ? holder : param.thisObject);
-                    ModuleLog.line("(IE|Story) url=" + url);
+                    Object effectiveHolder = holder != null ? holder : param.thisObject;
+                    StoryMediaOptions media = extractStoryMediaOptions(ctx, effectiveHolder);
+                    ModuleLog.line("(IE|Story) variants image="
+                            + (media != null && media.imageUrl != null)
+                            + " video=" + (media != null && media.videoUrl != null));
 
-                    if (url == null || url.isEmpty()) {
+                    if (media == null) {
                         Toast.makeText(ctx, I18n.t(ctx, R.string.ig_toast_story_url_not_found), Toast.LENGTH_SHORT).show();
                         return;
                     }
 
-                    Object effectiveHolder = holder != null ? holder : param.thisObject;
-                    currentStoryUsername = extractUsernameFromReelItemHolder(effectiveHolder);
-                    currentStoryMediaId  = extractMediaIdFromReelItemHolder(effectiveHolder);
-                    startDownload(ctx, url, isVideoUrl(url));
+                    String username = extractUsernameFromReelItemHolder(effectiveHolder);
+                    String mediaId = extractMediaIdFromReelItemHolder(effectiveHolder);
+                    handleStoryMedia(ctx, media, username, mediaId);
                 }
             });
 
@@ -238,14 +259,18 @@ public class StoryDownloadHook {
     }
 
     /**
-     * Extracts the story media URL from the holder object.
+     * Extracts every downloadable representation from the holder object.
      *   1. Reads the ReelItem field from the holder.
      *   2. Searches for VideoVersionIntf → video URL (videos).
      *   3. Searches for image Candidate objects (CDN URL + width int + height int) and
      *      picks the one with the largest pixel area (photos).
      *   4. Falls back to raw CDN string scan with area-based ranking.
+     *
+     * A photo story with music commonly exposes both image_versions2 (the original
+     * still) and video_versions (the rendered story with audio). Do not return after
+     * finding the MP4: keeping both URLs is what lets the user choose the JPG instead.
      */
-    private static String extractStoryUrl(Object holder) {
+    private static StoryMediaOptions extractStoryMediaOptions(Context ctx, Object holder) {
         if (holder == null) return null;
         try {
             Object reelItem = readFieldByTypeName(holder, "com.instagram.model.reels.ReelItem");
@@ -253,36 +278,102 @@ public class StoryDownloadHook {
                     (reelItem != null ? reelItem.getClass().getName() : "null"));
 
             Object target = reelItem != null ? reelItem : holder;
+            Object mediaObject = findMediaObject(target);
+            Object modelTarget = mediaObject != null ? mediaObject : target;
+            boolean modelSaysVideo = FeedVideoDownloadHook.isMediaVideo(modelTarget)
+                    || (modelTarget != target && FeedVideoDownloadHook.isMediaVideo(target));
 
-            // Try video URL via VideoVersionIntf scan
-            if (videoVersionIntfClass != null && videoVersionGetUrl != null) {
-                String videoUrl = findVideoUrl(target,
-                        Collections.newSetFromMap(new IdentityHashMap<>()), 0);
-                if (videoUrl != null) return videoUrl;
+            // Use the same source-aware extractor as feed/reels first. It understands
+            // Pando video_versions getters whose URLs no longer expose a video-looking path.
+            String videoUrl = FeedVideoDownloadHook.bestVideoUrlFromMedia(modelTarget);
+            if (videoUrl == null && modelTarget != target) {
+                videoUrl = FeedVideoDownloadHook.bestVideoUrlFromMedia(target);
             }
 
-            // For photo stories: walk the graph looking for image Candidate objects.
+            // Try video URL via VideoVersionIntf scan
+            if (videoUrl == null && videoVersionIntfClass != null && videoVersionGetUrl != null) {
+                videoUrl = findVideoUrl(target,
+                        Collections.newSetFromMap(new IdentityHashMap<>()), 0);
+                if (videoUrl != null) {
+                    FeedVideoDownloadHook.rememberVideoUrl(videoUrl);
+                }
+            }
+
+            // MediaExtKt knows the canonical image_versions2 URL and avoids choosing a
+            // smaller music-sticker/album-art image when a Media object is available.
+            String imageUrl = mediaObject != null
+                    ? FeedVideoDownloadHook.imageUrlFromMedia(ctx, mediaObject) : null;
+            if (imageUrl != null && FeedVideoDownloadHook.isVideoUrl(imageUrl)) {
+                imageUrl = null;
+            }
+
+            // Walk the graph looking for image Candidate objects when the canonical
+            // Media helper is unavailable.
             // A Candidate has a CDN URL string field + at least two int fields with
             // plausible pixel dimensions. Field names are obfuscated so we match by type
             // and value range. Pick the candidate with the largest width×height area.
-            List<CandidateInfo> candidates = new ArrayList<>();
-            collectImageCandidates(target, candidates,
-                    Collections.newSetFromMap(new IdentityHashMap<>()), 0);
-            ModuleLog.line("(IE|Story) imageCandidates=" + candidates.size());
-            if (!candidates.isEmpty()) {
-                candidates.sort((a, b) -> Integer.compare(b.area, a.area));
-                ModuleLog.line("(IE|Story) bestCandidate area=" + candidates.get(0).area
-                        + " url=" + candidates.get(0).url.substring(0, Math.min(80, candidates.get(0).url.length())));
-                return candidates.get(0).url;
+            if (imageUrl == null) {
+                List<CandidateInfo> candidates = new ArrayList<>();
+                collectImageCandidates(target, candidates,
+                        Collections.newSetFromMap(new IdentityHashMap<>()), 0);
+                ModuleLog.line("(IE|Story) imageCandidates=" + candidates.size());
+                if (!candidates.isEmpty()) {
+                    candidates.sort((a, b) -> Integer.compare(b.area, a.area));
+                    imageUrl = candidates.get(0).url;
+                    ModuleLog.line("(IE|Story) bestCandidate area=" + candidates.get(0).area);
+                }
             }
 
-            // Last resort: raw CDN string scan
+            // Last resort: split a raw CDN scan into image and video candidates. This
+            // never silently labels an image cover as a video (the issue #204 failure).
             List<String> cdnUrls = new ArrayList<>();
             scanCdnUrls(target, cdnUrls, 0, Collections.newSetFromMap(new IdentityHashMap<>()));
-            if (!cdnUrls.isEmpty()) return pickBestUrl(cdnUrls);
+            List<String> imageUrls = new ArrayList<>();
+            for (String candidate : cdnUrls) {
+                if (FeedVideoDownloadHook.isVideoUrl(candidate)) {
+                    if (videoUrl == null) {
+                        videoUrl = candidate;
+                        FeedVideoDownloadHook.rememberVideoUrl(candidate);
+                    }
+                } else {
+                    imageUrls.add(candidate);
+                }
+            }
+            if (imageUrl == null && !imageUrls.isEmpty()) imageUrl = pickBestUrl(imageUrls);
+
+            if (imageUrl == null && videoUrl == null) return null;
+            return new StoryMediaOptions(imageUrl, videoUrl, modelSaysVideo);
 
         } catch (Throwable t) {
-            ModuleLog.line("(IE|Story) extractStoryUrl error: " + t);
+            ModuleLog.line("(IE|Story) extractStoryMediaOptions error: " + t);
+        }
+        return null;
+    }
+
+    /** Resolves the Media nested in ReelItem without relying on obfuscated method names. */
+    private static Object findMediaObject(Object obj) {
+        if (obj == null) return null;
+        if (obj.getClass().getName().equals("com.instagram.feed.media.Media")) return obj;
+
+        Object direct = readFieldByTypeName(obj, "com.instagram.feed.media.Media");
+        if (direct != null) return direct;
+
+        Class<?> cls = obj.getClass();
+        while (cls != null && cls != Object.class) {
+            for (Method method : cls.getDeclaredMethods()) {
+                if (method.getParameterCount() != 0
+                        || java.lang.reflect.Modifier.isStatic(method.getModifiers())) continue;
+                Class<?> returnType = method.getReturnType();
+                if (returnType.isPrimitive() || returnType == String.class
+                        || returnType == void.class) continue;
+                try {
+                    method.setAccessible(true);
+                    Object result = method.invoke(obj);
+                    if (result != null && result.getClass().getName()
+                            .equals("com.instagram.feed.media.Media")) return result;
+                } catch (Throwable ignored) {}
+            }
+            cls = cls.getSuperclass();
         }
         return null;
     }
@@ -310,7 +401,10 @@ public class StoryDownloadHook {
         if (videoVersionIntfClass.isInstance(obj)) {
             try {
                 String url = (String) videoVersionGetUrl.invoke(obj);
-                if (url != null && isCdnUrl(url)) return url;
+                if (url != null && isCdnUrl(url)) {
+                    FeedVideoDownloadHook.rememberVideoUrl(url);
+                    return url;
+                }
             } catch (Throwable ignored) {}
         }
 
@@ -322,6 +416,7 @@ public class StoryDownloadHook {
         while (cls != null && cls != Object.class) {
             for (Field f : cls.getDeclaredFields()) {
                 try {
+                    if (java.lang.reflect.Modifier.isStatic(f.getModifiers())) continue;
                     f.setAccessible(true);
                     Object val = f.get(obj);
                     if (val == null) continue;
@@ -330,7 +425,10 @@ public class StoryDownloadHook {
                             if (videoVersionIntfClass.isInstance(elem)) {
                                 try {
                                     String url = (String) videoVersionGetUrl.invoke(elem);
-                                    if (url != null && isCdnUrl(url)) return url;
+                                    if (url != null && isCdnUrl(url)) {
+                                        FeedVideoDownloadHook.rememberVideoUrl(url);
+                                        return url;
+                                    }
                                 } catch (Throwable ignored) {}
                             }
                         }
@@ -360,6 +458,7 @@ public class StoryDownloadHook {
         while (cls != null && cls != Object.class) {
             for (Field f : cls.getDeclaredFields()) {
                 try {
+                    if (java.lang.reflect.Modifier.isStatic(f.getModifiers())) continue;
                     f.setAccessible(true);
                     Object val = f.get(obj);
                     if (val == null) continue;
@@ -414,6 +513,7 @@ public class StoryDownloadHook {
         Class<?> cls = obj.getClass();
         while (cls != null && cls != Object.class) {
             for (Field f : cls.getDeclaredFields()) {
+                if (java.lang.reflect.Modifier.isStatic(f.getModifiers())) continue;
                 f.setAccessible(true);
                 try {
                     if (f.getType() == String.class) {
@@ -468,6 +568,7 @@ public class StoryDownloadHook {
         while (cls != null && cls != Object.class) {
             for (Field f : cls.getDeclaredFields()) {
                 try {
+                    if (java.lang.reflect.Modifier.isStatic(f.getModifiers())) continue;
                     f.setAccessible(true);
                     Object val = f.get(obj);
                     if (val == null) continue;
@@ -516,7 +617,7 @@ public class StoryDownloadHook {
     }
 
     private static boolean isVideoUrl(String url) {
-        return url.contains("t50.") || url.contains("/o1/");
+        return FeedVideoDownloadHook.isVideoUrl(url);
     }
 
     /**
@@ -670,14 +771,60 @@ public class StoryDownloadHook {
 
     // ── Download dispatch ─────────────────────────────────────────────────────
 
-    private void startDownload(Context ctx, String url, boolean isVideo) {
-        String fn = FeedVideoDownloadHook.buildFilename(currentStoryUsername, "story", currentStoryMediaId, isVideo);
-        ModuleLog.line("(IE|Story|DL) username=" + currentStoryUsername + " mediaId=" + currentStoryMediaId
+    private void handleStoryMedia(Context ctx, StoryMediaOptions media,
+                                  String username, String mediaId) {
+        StoryDownloadChoicePolicy.Decision decision = StoryDownloadChoicePolicy.decide(
+                media.imageUrl != null, media.videoUrl != null, media.modelSaysVideo);
+        switch (decision) {
+            case DOWNLOAD_PHOTO -> startDownload(ctx, media.imageUrl, false, username, mediaId);
+            case DOWNLOAD_VIDEO -> startDownload(ctx, media.videoUrl, true, username, mediaId);
+            case ASK -> showStoryFormatDialog(ctx, media, username, mediaId);
+            case NOT_FOUND -> Toast.makeText(ctx,
+                    I18n.t(ctx, R.string.ig_toast_story_url_not_found), Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private void showStoryFormatDialog(Context ctx, StoryMediaOptions media,
+                                       String username, String mediaId) {
+        List<CharSequence> labels = new ArrayList<>();
+        List<StoryMedia> choices = new ArrayList<>();
+
+        // Photo first: this is the requested path for photo stories carrying music.
+        if (media.imageUrl != null) {
+            labels.add(I18n.t(ctx, R.string.ig_story_download_photo));
+            choices.add(new StoryMedia(media.imageUrl, false));
+        }
+        if (media.videoUrl != null) {
+            labels.add(I18n.t(ctx, R.string.ig_story_download_video_music));
+            choices.add(new StoryMedia(media.videoUrl, true));
+        }
+
+        try {
+            new AlertDialog.Builder(ctx)
+                    .setTitle(I18n.t(ctx, R.string.ig_story_download_choice_title))
+                    .setItems(labels.toArray(new CharSequence[0]), (dialog, which) -> {
+                        if (which < 0 || which >= choices.size()) return;
+                        StoryMedia choice = choices.get(which);
+                        startDownload(ctx, choice.url, choice.video, username, mediaId);
+                    })
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .show();
+        } catch (Throwable t) {
+            ModuleLog.line("(IE|Story) format dialog failed: " + t);
+            Toast.makeText(ctx, I18n.t(ctx, R.string.ig_toast_download_failed,
+                    t.getMessage()), Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private void startDownload(Context ctx, String url, boolean isVideo,
+                               String username, String mediaId) {
+        String fn = FeedVideoDownloadHook.buildFilename(username, "story", mediaId, isVideo);
+        ModuleLog.line("(IE|Story|DL) username=" + username + " mediaId=" + mediaId
                 + " file=" + fn);
         Toast.makeText(ctx, isVideo ? I18n.t(ctx, R.string.ig_toast_downloading_story_video) : I18n.t(ctx, R.string.ig_toast_downloading_story_photo), Toast.LENGTH_SHORT).show();
         mainHandler.post(() -> new Thread(() -> {
             try {
-                boolean delegated = FeedVideoDownloadHook.downloadAndSave(ctx, url, fn, isVideo, currentStoryUsername);
+                boolean delegated = FeedVideoDownloadHook.downloadAndSave(ctx, url, fn, isVideo, username);
                 if (!delegated) {
                     mainHandler.post(() -> Toast.makeText(ctx,
                             I18n.t(ctx, R.string.ig_toast_story_saved), Toast.LENGTH_SHORT).show());

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,0 +1,5 @@
+<resources>
+    <string name="ig_story_download_choice_title">Scarica storia</string>
+    <string name="ig_story_download_photo">Scarica foto</string>
+    <string name="ig_story_download_video_music">Scarica video con musica</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -434,6 +434,11 @@
     <string name="ig_dl_carousel_current">Download current (%1$d of %2$d)</string>
     <string name="ig_dl_carousel_all">Download all %1$d items</string>
 
+    <!-- Story download format -->
+    <string name="ig_story_download_choice_title">Download story</string>
+    <string name="ig_story_download_photo">Download photo</string>
+    <string name="ig_story_download_video_music">Download video with music</string>
+
     <!-- Story mentions -->
     <string name="ig_btn_view_mentions">View Mentions</string>
     <string name="ig_toast_mention_copied">@%1$s copied</string>

--- a/app/src/test/java/ps/reso/instaeclipse/mods/media/MediaModelResolverTest.java
+++ b/app/src/test/java/ps/reso/instaeclipse/mods/media/MediaModelResolverTest.java
@@ -1,0 +1,94 @@
+package ps.reso.instaeclipse.mods.media;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+import java.util.List;
+
+public class MediaModelResolverTest {
+
+    @Test
+    public void resolvesLiveTreeWhenLegacyInterfaceIsMissing() {
+        ClassLoader loader = new ClassLoader(getClass().getClassLoader()) {
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                if (MediaModelResolver.MUTABLE_DICT_CLASS.equals(name)) {
+                    throw new ClassNotFoundException(name);
+                }
+                if (MediaModelResolver.LIVE_TREE_DICT_CLASS.equals(name)) {
+                    return ModernDict.class;
+                }
+                return super.loadClass(name);
+            }
+        };
+
+        MediaModelResolver.Result result = MediaModelResolver.resolve(loader);
+
+        assertNull(result.mutableDictClass);
+        assertEquals(ModernDict.class, result.liveTreeDictClass);
+        assertEquals(1, result.listCandidates.size());
+        assertEquals("videoVersions", result.listCandidates.get(0).getName());
+    }
+
+    @Test
+    public void findsConcreteDictionaryStoredInObjectTypedField() {
+        ModernDict dict = new ModernDict();
+        MediaContainer media = new MediaContainer(dict);
+        MediaModelResolver.Result model = new MediaModelResolver.Result(
+                null, ModernDict.class, List.of());
+
+        Object found = MediaModelResolver.findDictionary(media, model, 2);
+
+        assertNotNull(found);
+        assertSame(dict, found);
+    }
+
+    @Test
+    public void findsDictionaryExposedOnlyByModelGetter() {
+        MethodOnlyContainer media = new MethodOnlyContainer();
+        MediaModelResolver.Result model = new MediaModelResolver.Result(
+                null, ModernDict.class, List.of());
+
+        Object found = MediaModelResolver.findDictionary(media, model, 2);
+
+        assertNotNull(found);
+        assertEquals(ModernDict.class, found.getClass());
+    }
+
+    @Test
+    public void findsDictionaryInsideIterableWrapper() {
+        ModernDict dict = new ModernDict();
+
+        Object found = MediaModelResolver.findObjectOfType(List.of(dict), ModernDict.class, 2);
+
+        assertSame(dict, found);
+    }
+
+    static final class MediaContainer {
+        private final Object backing;
+
+        MediaContainer(Object backing) {
+            this.backing = backing;
+        }
+    }
+
+    static final class ModernDict {
+        public List<String> videoVersions() {
+            return List.of("video");
+        }
+
+        public String unrelated() {
+            return "ignored";
+        }
+    }
+
+    static final class MethodOnlyContainer {
+        public ModernDict getExtendedData() {
+            return new ModernDict();
+        }
+    }
+}

--- a/app/src/test/java/ps/reso/instaeclipse/mods/media/MediaTypeDetectorTest.java
+++ b/app/src/test/java/ps/reso/instaeclipse/mods/media/MediaTypeDetectorTest.java
@@ -1,0 +1,52 @@
+package ps.reso.instaeclipse.mods.media;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+public class MediaTypeDetectorTest {
+
+    @Test
+    public void detectsMp4ByFtypEvenWhenUrlAndNameLookLikeImage() {
+        byte[] header = new byte[] {
+                0, 0, 0, 24, 'f', 't', 'y', 'p', 'i', 's', 'o', 'm', 0, 0, 0, 0
+        };
+
+        assertEquals(MediaTypeDetector.Kind.VIDEO,
+                MediaTypeDetector.sniff(header, header.length));
+        assertEquals("story_123.mp4", MediaTypeDetector.withCorrectExtension(
+                "story_123.jpg", MediaTypeDetector.Kind.VIDEO));
+    }
+
+    @Test
+    public void detectsJpegAndCorrectsWrongVideoExtension() {
+        byte[] header = new byte[] {(byte) 0xff, (byte) 0xd8, (byte) 0xff, (byte) 0xe0};
+
+        assertEquals(MediaTypeDetector.Kind.IMAGE,
+                MediaTypeDetector.sniff(header, header.length));
+        assertEquals("story_123.jpg", MediaTypeDetector.withCorrectExtension(
+                "story_123.mp4", MediaTypeDetector.Kind.IMAGE));
+    }
+
+    @Test
+    public void doesNotTreatHeicAsVideo() {
+        byte[] header = new byte[] {
+                0, 0, 0, 24, 'f', 't', 'y', 'p', 'h', 'e', 'i', 'c', 0, 0, 0, 0
+        };
+
+        assertEquals(MediaTypeDetector.Kind.IMAGE,
+                MediaTypeDetector.sniff(header, header.length));
+    }
+
+    @Test
+    public void usesContentTypeWhenSignatureIsUnknown() {
+        assertEquals(MediaTypeDetector.Kind.VIDEO,
+                MediaTypeDetector.fromContentType("video/mp4; charset=binary"));
+        assertEquals(MediaTypeDetector.Kind.IMAGE,
+                MediaTypeDetector.fromContentType("image/webp"));
+        assertEquals(MediaTypeDetector.Kind.UNKNOWN,
+                MediaTypeDetector.sniff("unknown".getBytes(StandardCharsets.US_ASCII), 7));
+    }
+}

--- a/app/src/test/java/ps/reso/instaeclipse/mods/media/StoryDownloadChoicePolicyTest.java
+++ b/app/src/test/java/ps/reso/instaeclipse/mods/media/StoryDownloadChoicePolicyTest.java
@@ -1,0 +1,38 @@
+package ps.reso.instaeclipse.mods.media;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class StoryDownloadChoicePolicyTest {
+
+    @Test
+    public void asksWhenPhotoAndMusicVideoAreBothAvailable() {
+        assertEquals(StoryDownloadChoicePolicy.Decision.ASK,
+                StoryDownloadChoicePolicy.decide(true, true, true));
+    }
+
+    @Test
+    public void downloadsPlainPhotoDirectly() {
+        assertEquals(StoryDownloadChoicePolicy.Decision.DOWNLOAD_PHOTO,
+                StoryDownloadChoicePolicy.decide(true, false, false));
+    }
+
+    @Test
+    public void downloadsVideoDirectlyWhenNoPhotoVariantExists() {
+        assertEquals(StoryDownloadChoicePolicy.Decision.DOWNLOAD_VIDEO,
+                StoryDownloadChoicePolicy.decide(false, true, true));
+    }
+
+    @Test
+    public void neverSilentlyTreatsVideoCoverAsVideo() {
+        assertEquals(StoryDownloadChoicePolicy.Decision.ASK,
+                StoryDownloadChoicePolicy.decide(true, false, true));
+    }
+
+    @Test
+    public void reportsMissingMedia() {
+        assertEquals(StoryDownloadChoicePolicy.Decision.NOT_FOUND,
+                StoryDownloadChoicePolicy.decide(false, false, false));
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes media downloads being saved with the wrong type and adds an
explicit format choice for Stories that expose both an image and a rendered
video.

## Fixes

- Resolves modern Instagram media models independently from the legacy
  `MutableMediaDictIntf`.
- Supports `LiveTreeMediaDict`/Pando video-version getters.
- Prevents Reels and video Stories from silently falling back to their JPG cover.
- Detects the downloaded payload from its signature and Content-Type.
- Corrects the filename extension and MIME type before saving.

## Story feature

When both variants are available, the Story downloader now offers:

- Download photo
- Download video with music

Plain photo Stories continue to download directly.

## Testing

- [x] `./gradlew testDebugUnitTest` — 14 tests passed
- [x] `./gradlew assembleDebug`
- [x] APK signature and archive integrity verified
- [ ] Manual test on Instagram/LSPosed after fully restarting the Instagram process

Fixes #204
