### PR TITLE
fix(ads): strip 'stkn' tracking parameter from copied links

### DIFF
--- a/app/src/main/java/ps/reso/instaeclipse/mods/ads/TrackingLinkDisable.java
+++ b/app/src/main/java/ps/reso/instaeclipse/mods/ads/TrackingLinkDisable.java
@@ -29,7 +29,8 @@ public class TrackingLinkDisable {
                         // Tracking params can appear anywhere in the query string, not just
                         // as the first one — matching only "?param=" (old behavior) missed
                         // links where another param came first, e.g. "?igshid=X&utm_source=...".
-                        boolean hasTracking = url.contains("igsh=")
+                        boolean hasTracking = url.contains("stkn=")
+                                || url.contains("igsh=")
                                 || url.contains("ig_rid=")
                                 || url.contains("utm_source=")
                                 || url.contains("story_media_id=")


### PR DESCRIPTION
### Summary
Instagram now includes `stkn=` in copied links. This adds `stkn=` to the tracking parameter check in `TrackingLinkDisable` so queries containing it are stripped clean.

**Example:**
- `https://www.instagram.com/reel/XYZ/?stkn=123...` ➔ `https://www.instagram.com/reel/XYZ/`